### PR TITLE
Make ProgressBarItem's value-now an observedAttribute

### DIFF
--- a/.changeset/tame-papayas-type.md
+++ b/.changeset/tame-papayas-type.md
@@ -1,0 +1,10 @@
+---
+"@gyldendal/kobber-components": patch
+"@gyldendal/kobber-base": patch
+"@gyldendal/kobber-eslint": patch
+"@gyldendal/kobber-prettier": patch
+"@gyldendal/kobber-scene": patch
+"@gyldendal/kobber-stylelint": patch
+---
+
+Add observedAttributes to progressBarItem

--- a/packages/kobber-components/src/progress-bar/ProgressBar.stories.ts
+++ b/packages/kobber-components/src/progress-bar/ProgressBar.stories.ts
@@ -9,7 +9,6 @@ const meta: Meta = {
   component: "kobber-progress-bar",
   tags: ["autodocs"],
   args: {
-    __progressBarFirstValue: 45,
     height: "default",
   },
   argTypes: {
@@ -17,19 +16,11 @@ const meta: Meta = {
       control: "inline-radio",
       options: ["default", "low"],
     },
-    __progressBarFirstValue: {
-      name: "Value",
-      description: "In reality, the sum of the bars' values will never exceed 100&nbsp;%.",
-      control: { type: "range", min: 0, max: 100 },
-      table: {
-        category: "First bar",
-      },
-    },
   },
   decorators: [
     (story, storyContext) => `
     <div 
-      style="display: grid; grid-template-columns: repeat(3, 200px)"
+      style="display: grid; grid-template-columns: repeat(3, 200px); gap: 0.5em;"
       class="${storyContext.globals.theme}"
     >
       ${story()}
@@ -76,11 +67,33 @@ export const Single: Story = {
       >
         <${ProgressBarItem} 
           ariaLabel="Måloppnåelse"
-          value-now="${args.__progressBarFirstValue}"
+          value-now="45"
           fill-color="${getFillColor(args)}"
           filled-color="${filledColor}"
         ></${ProgressBarItem}>
     </${ProgressBar}>
+
+    <label style="grid-column: 2;">
+      Change value
+      <input type="number" value="45" class="storybook-progress-bar-value" min="0" max="100" />
+    </label>
+
+    <script>
+      const valueSelector = document.querySelector(".storybook-progress-bar-value");
+      const progressBarItem = document.querySelector("${ProgressBarItem}");
+      valueSelector.addEventListener("change", (event) => {
+        if(progressBarItem) {
+          progressBarItem.setAttribute("value-now", event.target.value);
+        }
+      });
+    </script>
+
+    <details style="grid-column: 1/-1;">
+     <summary>Why not use a storybook control?</summary>
+     Because storybook re-renders stories when controls change. This creates the illusion that we don't need to observe for attribute changes.<br />
+     When component is used in real life, re-rendering does not occur, and observing needs to be in place.<br />
+     By using this input instead of a storybook control, we see something closer to what real-world usage looks like.
+    </details>
     `;
   },
   args: {
@@ -123,11 +136,20 @@ export const Double: Story = {
   },
   args: {
     spaceBetweenBars: true,
+    __progressBarFirstValue: 45,
     __progressBarSecondValue: 40,
     __progressColor: "low",
     height: "low",
   },
   argTypes: {
+    __progressBarFirstValue: {
+      name: "Value",
+      description: "In reality, the sum of the bars' values will never exceed 100&nbsp;%.",
+      control: { type: "range", min: 0, max: 100 },
+      table: {
+        category: "First bar",
+      },
+    },
     __progressBarSecondValue: {
       name: "Value",
       control: { type: "range", min: 0, max: 100 },
@@ -149,6 +171,9 @@ export const Double: Story = {
  * A special use case, where there is just one bar, and the background should match the bar's color.
  */
 export const Proficiency: Story = {
+  args: {
+    __progressBarFirstValue: 45,
+  },
   argTypes: {
     height: {
       table: {

--- a/packages/kobber-components/src/progress-bar/ProgressBarItem.js
+++ b/packages/kobber-components/src/progress-bar/ProgressBarItem.js
@@ -13,25 +13,24 @@ export class ProgressBarItem extends HTMLElement {
   constructor() {
     super();
     this.attachShadow({ mode: "open" });
+    this.valueNow;
     this.fillColorFallback = "var(--kobber-component-progressbar-color-foreground-default-primary)";
     this.heightValueFallback = "var(--kobber-component-progressbar-color-background-default)";
     this.borderRadiusValueFallback = "var(--kobber-component-progressbar-border-radius)";
   }
 
-  connectedCallback() {
+  renderComponent() {
     const ariaLabel =
       this.getAttribute("ariaLabel") ||
       ""; /* Do not use aria-labelledby, as IDREFs don't work across light DOM and shadow DOM. */
     const explainOtherUnitThanPercentage = this.getAttribute("explainOtherUnitThanPercentage") || "";
-    const valueNow = this.getAttribute("value-now");
     const valueMin = this.getAttribute("value-min") || "0";
     const valueMax = this.getAttribute("value-max") || "100";
     const fillColor = this.getAttribute("fill-color") || this.fillColorFallback;
     const filledColor = this.getAttribute("filled-color") || "";
 
-    const widthInPercent = (100.0 * valueNow) / (valueMax - valueMin);
-
-    const fillColorValue = valueNow === valueMax && filledColor !== "" ? filledColor : fillColor;
+    const widthInPercent = (100.0 * this.valueNow) / (valueMax - valueMin);
+    const fillColorValue = this.valueNow === valueMax && filledColor !== "" ? filledColor : fillColor;
 
     this.shadowRoot.innerHTML = `
     <style>
@@ -55,13 +54,32 @@ export class ProgressBarItem extends HTMLElement {
     <div 
       class="fill"
       role="progressbar"
-      aria-valuenow="${valueNow}"
+      aria-valuenow="${this.valueNow}"
       aria-valuemin="${valueMin}"
       aria-label="${ariaLabel}"
       aria-valuetext="${explainOtherUnitThanPercentage}"
       aria-valuemax="${valueMax}"
     ></div>
   `;
+  }
+
+  connectedCallback() {
+    this.valueNow = this.getAttribute("value-now");
+    this.renderComponent();
+  }
+
+  attributeChangedCallback(name, oldValue, newValue) {
+    const progressBar = this.shadowRoot.querySelector("[role='progressbar']");
+    if (progressBar) {
+      if (name === "value-now") {
+        this.valueNow = newValue;
+      }
+      this.renderComponent();
+    }
+  }
+
+  static get observedAttributes() {
+    return ["value-now"];
   }
 }
 


### PR DESCRIPTION
And replace storybook control with custom input, to prove that it works even when the story doesn't re-render (which storybook does when a control value changes).

This is required for SmartVurdering, so students can see that their overall progress updates as they work.