### PR TITLE
Add progressbar border

### DIFF
--- a/packages/kobber-components/src/progress-bar/ProgressBar.js
+++ b/packages/kobber-components/src/progress-bar/ProgressBar.js
@@ -59,6 +59,7 @@ export class ProgressBar extends HTMLElement {
       .list {
         border-radius: inherit;
         background-color: ${backgroundColor};
+        border: 1px solid;
       }
         
       slot {


### PR DESCRIPTION
For contrast (= better accessibility). This ensures there is always a border around the bar background (which can be hidden, if you absolutely want that).

This is wanted in Smart Vurdering
(https://gyldendaldigital.atlassian.net/browse/SV-797)