### PR TITLE
Add extension to tokens import

### DIFF
--- a/packages/kobber-components/src/grid/gridConfig/getCardGridBase.ts
+++ b/packages/kobber-components/src/grid/gridConfig/getCardGridBase.ts
@@ -1,4 +1,4 @@
-import { layout } from "@gyldendal/kobber-base/themes/default/tokens";
+import { layout } from "@gyldendal/kobber-base/themes/default/tokens.js";
 import { GridConfig } from "./types";
 
 interface GetCardGridBaseOptions {


### PR DESCRIPTION
Without this, Smart Vurdering's azure pipeline fails (even if SV doesn't use kobber's grid).