### PR TITLE
Removed static css build from kobber-components

### DIFF
--- a/packages/kobber-components/README.md
+++ b/packages/kobber-components/README.md
@@ -68,24 +68,6 @@ document.body.appendChild(progressBar);
 
 ## CSS
 
-CSS can be imported in JavaScript if supported by your bundler:
-
-```JavaScript
-import "@gyldendal/kobber-base/css/components.css";
-```
-
-<mark>
-Kanskje vi bør inkludere vår egen css baseline i stedet for dette? ↓
-<br />
-Slik som https://mui.com/material-ui/react-css-baseline/</mark>
-
-kobber-components assumes that `box-sizing` is set to `border-box`:
-
-```css
-html { box-sizing: border-box; }
-*, *::before, *::after { box-sizing: inherit; }
-```
-
 We recommend using [normalize.css](https://github.com/necolas/normalize.css/) or something similar to normalize browser styles.
 
 ## Development

--- a/packages/kobber-components/package.json
+++ b/packages/kobber-components/package.json
@@ -5,7 +5,6 @@
   "type": "module",
   "files": [
     "chunks/**/*",
-    "css/**/*",
     "react/**/*",
     "react-ssr-safe/**/*",
     "web-components/**/*"

--- a/packages/kobber-components/tsup.config.ts
+++ b/packages/kobber-components/tsup.config.ts
@@ -9,8 +9,6 @@ const reactSsrSafeDirectory = "react-ssr-safe";
 
 const webComponentsDirectory = "web-components";
 
-const cssDirectory = "css";
-
 const removeDirectory = (directory: string) => {
   if (!fs.existsSync(directory)) return;
   fs.rmdirSync(directory, { recursive: true });
@@ -20,7 +18,6 @@ removeDirectory(chunks);
 removeDirectory(reactDirectory);
 removeDirectory(reactSsrSafeDirectory);
 removeDirectory(webComponentsDirectory);
-removeDirectory(cssDirectory);
 
 export default defineConfig(() => ({
   entry: {
@@ -34,22 +31,7 @@ export default defineConfig(() => ({
   clean: false,
   bundle: true,
   external: ["react"],
-  loader: { ".css": "local-css" },
   esbuildOptions(options) {
     options.chunkNames = `${chunks}/[name]-[hash]`;
   },
-  async onSuccess() {
-    moveCss();
-  },
 }));
-
-// The react and web-components directories now contains equal css files.
-// Move one css file to the css directory and remove the other.
-
-const moveCss = () => {
-  if (fs.existsSync(`${reactDirectory}/index.css`)) {
-    fs.mkdirSync(cssDirectory);
-    fs.renameSync(`${reactDirectory}/index.css`, `${cssDirectory}/components.css`);
-    fs.rmSync(`${webComponentsDirectory}/index.css`);
-  }
-};


### PR DESCRIPTION
No components are importing css modules, so this is not needed anymore.