### PR TITLE
Kobber base token refactor

### DIFF
--- a/packages/kobber-base/build.ts
+++ b/packages/kobber-base/build.ts
@@ -8,7 +8,11 @@ import { tokensFromFigma } from "./tokens-from-figma";
  *
  * Run by the build script in package.json
  */
-themeConfigs.forEach(themeConfig => {
-  buildThemeTokens(tokensFromFigma, themeConfig);
-  buildTypography(themeConfig);
-});
+const build = async () => {
+  for (const themeConfig of themeConfigs) {
+    await buildThemeTokens(tokensFromFigma, themeConfig);
+    buildTypography(themeConfig);
+  }
+};
+
+await build();

--- a/packages/kobber-base/build.ts
+++ b/packages/kobber-base/build.ts
@@ -2,6 +2,7 @@ import { themeConfigs } from "./buildConfig";
 import { buildTypography } from "./src/typography/buildTypography";
 import { buildThemeTokens } from "./src/styleDictionary/buildThemeTokens";
 import { tokensFromFigma } from "./tokens-from-figma";
+import { cleanFolder as clean } from "./src/utils/cleanFolder";
 
 /**
  * Converts json from Figma into css, js, scss ++
@@ -9,6 +10,8 @@ import { tokensFromFigma } from "./tokens-from-figma";
  * Run by the build script in package.json
  */
 const build = async () => {
+  clean();
+
   for (const themeConfig of themeConfigs) {
     await buildThemeTokens(tokensFromFigma, themeConfig);
     buildTypography(themeConfig);

--- a/packages/kobber-base/build.ts
+++ b/packages/kobber-base/build.ts
@@ -2,7 +2,7 @@ import { themeConfigs } from "./buildConfig";
 import { buildTypography } from "./src/typography/buildTypography";
 import { buildThemeTokens } from "./src/styleDictionary/buildThemeTokens";
 import { tokensFromFigma } from "./tokens-from-figma";
-import { cleanFolder as clean } from "./src/utils/cleanFolder";
+import { cleanThemeDirectory } from "./src/utils/cleanFolder";
 
 /**
  * Converts json from Figma into css, js, scss ++
@@ -10,10 +10,11 @@ import { cleanFolder as clean } from "./src/utils/cleanFolder";
  * Run by the build script in package.json
  */
 const build = async () => {
-  clean();
+  cleanThemeDirectory();
 
   for (const themeConfig of themeConfigs) {
     await buildThemeTokens(tokensFromFigma, themeConfig);
+
     buildTypography(themeConfig);
   }
 };

--- a/packages/kobber-base/package.json
+++ b/packages/kobber-base/package.json
@@ -19,7 +19,7 @@
   },
   "devDependencies": {
     "@types/node": "^20.9.0",
-    "style-dictionary": "^3.9.0",
+    "style-dictionary": "^4.3.0",
     "tsx": "^4.6.2",
     "typescript": "^5.6.3"
   }

--- a/packages/kobber-base/src/styleDictionary/buildThemeTokens.ts
+++ b/packages/kobber-base/src/styleDictionary/buildThemeTokens.ts
@@ -11,20 +11,20 @@ import { additionalTokens } from "./additionalTokens";
 /**
  * Convert Figma modes into themes
  */
-export const buildThemeTokens = (tokensFromFigma: any, themeConfig: ThemeConfig) => {
+export const buildThemeTokens = async (tokensFromFigma: any, themeConfig: ThemeConfig) => {
   registerFormats([jsonFormat, esmFormat, tsDeclarationsFormat]);
 
   const allTokens = getAllTokens(tokensFromFigma, themeConfig);
 
-  const styleDictionaryConfig = getStyleDictionaryConfig(allTokens, themeConfig);
+  const sdConfig = getStyleDictionaryConfig(allTokens, themeConfig);
 
   try {
-    StyleDictionary.extend(styleDictionaryConfig).buildAllPlatforms();
+    const sd = new StyleDictionary(sdConfig);
+    await sd.hasInitialized;
+    console.log("tokens", sd.tokens);
   } catch (error) {
     console.error(error);
   }
-
-  return { allTokens, styleDictionaryConfig };
 };
 
 // Merge tokens from Figma and temporary, hardcoded tokens

--- a/packages/kobber-base/src/styleDictionary/buildThemeTokens.ts
+++ b/packages/kobber-base/src/styleDictionary/buildThemeTokens.ts
@@ -21,7 +21,7 @@ export const buildThemeTokens = async (tokensFromFigma: any, themeConfig: ThemeC
   try {
     const sd = new StyleDictionary(sdConfig);
     await sd.hasInitialized;
-    console.log("tokens", sd.tokens);
+    await sd.buildAllPlatforms();
   } catch (error) {
     console.error(error);
   }

--- a/packages/kobber-base/src/styleDictionary/buildThemeTokens.ts
+++ b/packages/kobber-base/src/styleDictionary/buildThemeTokens.ts
@@ -1,38 +1,51 @@
 import StyleDictionary from "style-dictionary";
 import { ThemeConfig } from "../types";
 import { esmFormat } from "./formats/esm";
-import { jsonFormat } from "./formats/json";
 import { tsDeclarationsFormat } from "./formats/tsDeclarations";
 import { getStyleDictionaryConfig } from "./getStyleDictionaryConfig";
 import { registerFormats } from "./registerFormats";
 import { sanitizeJsonFromFigma } from "./sanitizeJsonFromFigma";
 import { additionalTokens } from "./additionalTokens";
+import { esmWithCssVariableValues } from "./formats/esmWithCssVariableValues";
+import { registerTransforms } from "./registerTransforms";
+import { fluidClampTransform } from "./transforms/fluidClamp";
 
 /**
  * Convert Figma modes into themes
  */
-export const buildThemeTokens = async (tokensFromFigma: any, themeConfig: ThemeConfig) => {
-  registerFormats([jsonFormat, esmFormat, tsDeclarationsFormat]);
+export const buildThemeTokens = async (
+  tokensFromFigma: any,
+  themeConfig: ThemeConfig,
+  includeAdditionalTokens = true,
+) => {
+  registerFormats([esmFormat, tsDeclarationsFormat, esmWithCssVariableValues]);
+  registerTransforms([fluidClampTransform]);
 
-  const allTokens = getAllTokens(tokensFromFigma, themeConfig);
+  const allTokens = getAllTokens(tokensFromFigma, themeConfig, includeAdditionalTokens);
 
-  const sdConfig = getStyleDictionaryConfig(allTokens, themeConfig);
+  const styleDictionaryConfig = getStyleDictionaryConfig(allTokens, themeConfig);
 
   try {
-    const sd = new StyleDictionary(sdConfig);
+    const sd = new StyleDictionary(styleDictionaryConfig);
     await sd.hasInitialized;
     await sd.buildAllPlatforms();
+    return { allTokens, styleDictionaryConfig };
   } catch (error) {
     console.error(error);
+    throw new Error("Failed to build tokens");
   }
 };
 
 // Merge tokens from Figma and temporary, hardcoded tokens
-const getAllTokens = (tokensFromFigma: any, themeConfig: ThemeConfig) => {
+const getAllTokens = (tokensFromFigma: any, themeConfig: ThemeConfig, includeAdditionalTokens = true) => {
   const sanitizedJson = sanitizeJsonFromFigma(JSON.stringify(tokensFromFigma), themeConfig);
 
-  return {
-    ...sanitizedJson,
-    ...additionalTokens,
-  };
+  if (includeAdditionalTokens) {
+    return {
+      ...sanitizedJson,
+      ...additionalTokens,
+    };
+  }
+
+  return sanitizedJson;
 };

--- a/packages/kobber-base/src/styleDictionary/formats/esm.ts
+++ b/packages/kobber-base/src/styleDictionary/formats/esm.ts
@@ -1,9 +1,9 @@
-import { Format, Named } from "style-dictionary";
+import type { Format } from "style-dictionary/types";
 import { minifyDictionary } from "../../utils/minifyDictionary";
 
-export const esmFormat: Named<Format> = {
+export const esmFormat: Format = {
   name: "esm/nested",
-  formatter: ({ dictionary }) => {
+  format: ({ dictionary }) => {
     const minified = minifyDictionary(dictionary.tokens) ?? {};
     return Object.entries(minified)
       .map(([name, value]) => {

--- a/packages/kobber-base/src/styleDictionary/formats/esmWithCssVariableValues.ts
+++ b/packages/kobber-base/src/styleDictionary/formats/esmWithCssVariableValues.ts
@@ -1,0 +1,57 @@
+import type { Format, TransformedToken } from "style-dictionary/types";
+import { propertyFormatNames } from "style-dictionary/enums";
+import { createPropertyFormatter } from "style-dictionary/utils";
+import { TransformedTokens } from "style-dictionary";
+
+export const esmWithCssVariableValues: Format = {
+  name: "esm/css-variable-values",
+  format: async ({ dictionary }) => {
+    const formatProperty = createPropertyFormatter({
+      outputReferences: false,
+      dictionary,
+      format: propertyFormatNames.css,
+    });
+
+    const transformedTokens = transformValuesToCssVariables(dictionary.tokens, formatProperty) ?? {};
+
+    return Object.entries(transformedTokens)
+      .map(([name, value]) => {
+        return `export const ${name} = ${JSON.stringify(value, null, 2)};`;
+      })
+      .join("\n\n");
+  },
+};
+
+export const transformValuesToCssVariables = (
+  object: TransformedTokens,
+  cssTransform: (token: TransformedToken) => string,
+) => {
+  if (object === null || object === undefined) {
+    return null;
+  }
+
+  if (typeof object !== "object" || Array.isArray(object)) {
+    return object;
+  }
+
+  if (object.hasOwnProperty("value") && isToken(object)) {
+    object.value = cssTransform(object).split(":", 1)[0].trim();
+    return object.value;
+  }
+
+  var transformed: TransformedTokens = {};
+
+  for (const name in object) {
+    if (object.hasOwnProperty(name)) {
+      const value = transformValuesToCssVariables(object[name], cssTransform);
+      if (value) {
+        transformed[name] = value;
+      }
+    }
+  }
+
+  return transformed;
+};
+
+const isToken = (token: TransformedTokens | TransformedToken): token is TransformedToken =>
+  (token as TransformedToken)?.name !== undefined;

--- a/packages/kobber-base/src/styleDictionary/formats/json.ts
+++ b/packages/kobber-base/src/styleDictionary/formats/json.ts
@@ -1,9 +1,9 @@
-import { Format, Named } from "style-dictionary";
+import { Format } from "style-dictionary/types";
 import { minifyDictionary } from "../../utils/minifyDictionary";
 
-export const jsonFormat: Named<Format> = {
+export const jsonFormat: Format = {
   name: "json/nested-v2",
-  formatter: ({ dictionary, options }) => {
+  format: ({ dictionary }) => {
     const minified = minifyDictionary(dictionary.tokens);
     return JSON.stringify(minified, null, 2);
   },

--- a/packages/kobber-base/src/styleDictionary/formats/json.ts
+++ b/packages/kobber-base/src/styleDictionary/formats/json.ts
@@ -1,6 +1,7 @@
 import { Format } from "style-dictionary/types";
 import { minifyDictionary } from "../../utils/minifyDictionary";
 
+/** @deprecated Use the built-in JSON format instead: https://styledictionary.com/reference/hooks/formats/predefined/#jsonnested */
 export const jsonFormat: Format = {
   name: "json/nested-v2",
   format: ({ dictionary }) => {

--- a/packages/kobber-base/src/styleDictionary/formats/tsDeclarations.ts
+++ b/packages/kobber-base/src/styleDictionary/formats/tsDeclarations.ts
@@ -1,9 +1,9 @@
-import { Format, Named } from "style-dictionary";
+import { Format } from "style-dictionary/types";
 import { minifyDictionary } from "../../utils/minifyDictionary";
 
-export const tsDeclarationsFormat: Named<Format> = {
+export const tsDeclarationsFormat: Format = {
   name: "ts-declarations/nested",
-  formatter: ({ dictionary }) => {
+  format: ({ dictionary }) => {
     const minified = minifyDictionary(dictionary.tokens) ?? {};
     return Object.entries(minified)
       .map(([name, value]) => {

--- a/packages/kobber-base/src/styleDictionary/getStyleDictionaryConfig.ts
+++ b/packages/kobber-base/src/styleDictionary/getStyleDictionaryConfig.ts
@@ -1,4 +1,4 @@
-import StyleDictionary from "style-dictionary";
+import type { TransformedToken, Config } from "style-dictionary/types";
 import { esmFormat } from "./formats/esm";
 import { jsonFormat } from "./formats/json";
 import { cssTransforms, jsTransforms, registerTransforms } from "./registerTransforms";
@@ -11,7 +11,7 @@ const buildPath = themeDirectory + "/";
 
 const invalidKeys = ["font"];
 
-const filter = (token: StyleDictionary.TransformedToken) => !invalidKeys.includes(token.path[0]);
+const filter = (token: TransformedToken) => !invalidKeys.includes(token.path[0]);
 
 /**
  * Create a config object from tokens, transforms and formats
@@ -20,7 +20,7 @@ export const getStyleDictionaryConfig = (
   sanitizedTokensFromFigma: any,
   themeConfig: ThemeConfig,
   transforms: string[] = [],
-): StyleDictionary.Config => {
+): Config => {
   registerTransforms([pxToRemTransform, fluidClampTransform]);
 
   return {

--- a/packages/kobber-base/src/styleDictionary/getStyleDictionaryConfig.ts
+++ b/packages/kobber-base/src/styleDictionary/getStyleDictionaryConfig.ts
@@ -26,17 +26,6 @@ export const getStyleDictionaryConfig = (
   return {
     tokens: sanitizedTokensFromFigma,
     platforms: {
-      scss: {
-        transforms: [...cssTransforms, ...transforms],
-        buildPath,
-        files: [
-          {
-            destination: `${themeConfig.themeName}/tokens.scss`,
-            format: "scss/variables",
-            filter,
-          },
-        ],
-      },
       css: {
         transforms: [...cssTransforms, ...transforms],
         buildPath,
@@ -57,21 +46,21 @@ export const getStyleDictionaryConfig = (
         transforms: [...jsTransforms, ...transforms],
         buildPath,
         files: [
-          {
-            destination: `${themeConfig.themeName}/tokens.json`,
-            format: jsonFormat.name,
-            filter,
-          },
+          // {
+          //   destination: `${themeConfig.themeName}/tokens.json`,
+          //   format: jsonFormat.name,
+          //   filter,
+          // },
           {
             destination: `${themeConfig.themeName}/tokens.js`,
             format: esmFormat.name,
             filter,
           },
-          {
-            destination: `${themeConfig.themeName}/tokens.d.ts`,
-            format: tsDeclarationsFormat.name,
-            filter,
-          },
+          // {
+          //   destination: `${themeConfig.themeName}/tokens.d.ts`,
+          //   format: tsDeclarationsFormat.name,
+          //   filter,
+          // },
         ],
       },
     },

--- a/packages/kobber-base/src/styleDictionary/registerFormats.ts
+++ b/packages/kobber-base/src/styleDictionary/registerFormats.ts
@@ -1,6 +1,7 @@
 import StyleDictionary from "style-dictionary";
+import type { Format } from "style-dictionary/types";
 
-export const registerFormats = (formats: StyleDictionary.Named<StyleDictionary.Format>[]) => {
+export const registerFormats = (formats: Format[]) => {
   formats.forEach(f => StyleDictionary.registerFormat(f));
   console.log(`Formats registered: ${formats.map(f => f.name).join(", ")}`);
 };

--- a/packages/kobber-base/src/styleDictionary/registerTransforms.ts
+++ b/packages/kobber-base/src/styleDictionary/registerTransforms.ts
@@ -5,16 +5,16 @@ import { pxToRemTransform } from "./transforms/pxToRem";
 
 export const cssTransforms = [
   "attribute/cti",
-  "name/cti/kebab",
+  "name/kebab",
   "time/seconds",
-  "content/icon",
+  "html/icon",
   "size/rem",
   "color/css",
   fluidClampTransform.name,
   pxToRemTransform.name,
 ];
 
-export const jsTransforms = ["attribute/cti", "name/cti/pascal", "size/rem", "color/hex", fluidClampTransform.name];
+export const jsTransforms = ["attribute/cti", "name/pascal", "size/rem", "color/hex", fluidClampTransform.name];
 
 export const registerTransforms = (transforms: Transform[]) => {
   transforms.forEach(t => StyleDictionary.registerTransform(t));

--- a/packages/kobber-base/src/styleDictionary/registerTransforms.ts
+++ b/packages/kobber-base/src/styleDictionary/registerTransforms.ts
@@ -2,13 +2,13 @@ import StyleDictionary from "style-dictionary";
 import type { Transform } from "style-dictionary/types";
 import { fluidClampTransform } from "./transforms/fluidClamp";
 
+/** Docs: https://styledictionary.com/reference/hooks/transforms/predefined */
 export const cssTransforms = [
   "attribute/cti",
   "name/kebab",
   "time/seconds",
   "html/icon",
-  // "size/pxToRem", // removed until we decide to use rem
-  // "size/rem", // Figma numbers units are in px // https://styledictionary.com/reference/hooks/transforms/predefined/#sizerem
+  "size/pxToRem",
   "color/css",
   fluidClampTransform.name,
 ];
@@ -16,7 +16,7 @@ export const cssTransforms = [
 export const jsTransforms = [
   "attribute/cti",
   "name/pascal",
-  // "size/pxToRem", // removed until we decide to use rem
+  // "size/pxToRem", // Keep px values in JS for calculations
   "color/hex",
   fluidClampTransform.name,
 ];

--- a/packages/kobber-base/src/styleDictionary/registerTransforms.ts
+++ b/packages/kobber-base/src/styleDictionary/registerTransforms.ts
@@ -1,4 +1,5 @@
 import StyleDictionary from "style-dictionary";
+import type { Transform } from "style-dictionary/types";
 import { fluidClampTransform } from "./transforms/fluidClamp";
 import { pxToRemTransform } from "./transforms/pxToRem";
 
@@ -15,7 +16,7 @@ export const cssTransforms = [
 
 export const jsTransforms = ["attribute/cti", "name/cti/pascal", "size/rem", "color/hex", fluidClampTransform.name];
 
-export const registerTransforms = (transforms: StyleDictionary.Named<StyleDictionary.Transform>[]) => {
+export const registerTransforms = (transforms: Transform[]) => {
   transforms.forEach(t => StyleDictionary.registerTransform(t));
   console.log(`Transforms registered: ${transforms.map(f => f.name).join(", ")}`);
 };

--- a/packages/kobber-base/src/styleDictionary/registerTransforms.ts
+++ b/packages/kobber-base/src/styleDictionary/registerTransforms.ts
@@ -1,20 +1,25 @@
 import StyleDictionary from "style-dictionary";
 import type { Transform } from "style-dictionary/types";
 import { fluidClampTransform } from "./transforms/fluidClamp";
-import { pxToRemTransform } from "./transforms/pxToRem";
 
 export const cssTransforms = [
   "attribute/cti",
   "name/kebab",
   "time/seconds",
   "html/icon",
-  "size/rem",
+  // "size/pxToRem", // removed until we decide to use rem
+  // "size/rem", // Figma numbers units are in px // https://styledictionary.com/reference/hooks/transforms/predefined/#sizerem
   "color/css",
   fluidClampTransform.name,
-  pxToRemTransform.name,
 ];
 
-export const jsTransforms = ["attribute/cti", "name/pascal", "size/rem", "color/hex", fluidClampTransform.name];
+export const jsTransforms = [
+  "attribute/cti",
+  "name/pascal",
+  // "size/pxToRem", // removed until we decide to use rem
+  "color/hex",
+  fluidClampTransform.name,
+];
 
 export const registerTransforms = (transforms: Transform[]) => {
   transforms.forEach(t => StyleDictionary.registerTransform(t));

--- a/packages/kobber-base/src/styleDictionary/sanitizeJsonFromFigma.ts
+++ b/packages/kobber-base/src/styleDictionary/sanitizeJsonFromFigma.ts
@@ -15,20 +15,20 @@ export const sanitizeJsonFromFigma = (tokensFromFigmaString: string, themeConfig
   const json = JSON.parse(replaced);
 
   // Missing references (remove when fixed)
-  json.semantics.action.border = {
-    radius: {
-      xxsmall: {
-        type: "dimension",
-        value: 0,
-      },
-    },
-  };
-  json.primitives.border = {
-    [10]: {
-      type: "dimension",
-      value: 0,
-    },
-  };
+  // json.semantics.action.border = {
+  //   radius: {
+  //     xxsmall: {
+  //       type: "dimension",
+  //       value: 0,
+  //     },
+  //   },
+  // };
+  // json.primitives.border = {
+  //   [10]: {
+  //     type: "dimension",
+  //     value: 0,
+  //   },
+  // };
 
   console.log(`Sanitized tokens name=${themeConfig.themeName} mode=${themeConfig.figmaMode}`);
 

--- a/packages/kobber-base/src/styleDictionary/sanitizeJsonFromFigma.ts
+++ b/packages/kobber-base/src/styleDictionary/sanitizeJsonFromFigma.ts
@@ -14,22 +14,6 @@ export const sanitizeJsonFromFigma = (tokensFromFigmaString: string, themeConfig
   // Return JSON that do not include objects with mode names in them
   const json = JSON.parse(replaced);
 
-  // Missing references (remove when fixed)
-  // json.semantics.action.border = {
-  //   radius: {
-  //     xxsmall: {
-  //       type: "dimension",
-  //       value: 0,
-  //     },
-  //   },
-  // };
-  // json.primitives.border = {
-  //   [10]: {
-  //     type: "dimension",
-  //     value: 0,
-  //   },
-  // };
-
   console.log(`Sanitized tokens name=${themeConfig.themeName} mode=${themeConfig.figmaMode}`);
 
   return {

--- a/packages/kobber-base/src/styleDictionary/transforms/fluidClamp.ts
+++ b/packages/kobber-base/src/styleDictionary/transforms/fluidClamp.ts
@@ -1,7 +1,7 @@
 import type { Transform, TransformedToken } from "style-dictionary/types";
 import { fluidClamp } from "../../utils/fluid";
 
-const isClamp = (token: TransformedToken) =>
+const isClamp = (token: TransformedToken): token is TokenClampTransformedToken =>
   (token?.$type === "fluidClamp" || token?.type === "fluidClamp") &&
   typeof token.value === "object" &&
   "min" in token.value &&
@@ -10,20 +10,30 @@ const isClamp = (token: TransformedToken) =>
   "viewportMax" in token.value &&
   "unit" in token.value;
 
-type TokenClamp = {
+interface TokenClampTransformedToken extends TransformedToken {
+  value: TokenClamp;
+}
+
+interface TokenClamp {
   min: number;
   max: number;
   viewportMin: number;
   viewportMax: number;
   unit: string;
-};
+}
 
 export const fluidClampTransform: Transform = {
   name: "fluidClamp",
   type: "value",
   transitive: true,
   filter: isClamp,
-  transform: ({ value }: { value: TokenClamp }) => {
+  transform: token => {
+    if (!isClamp(token)) {
+      return token.value;
+    }
+
+    const { value } = token;
+
     return fluidClamp(value.min, value.max, value.viewportMin, value.viewportMax, value.unit);
   },
 };

--- a/packages/kobber-base/src/styleDictionary/transforms/fluidClamp.ts
+++ b/packages/kobber-base/src/styleDictionary/transforms/fluidClamp.ts
@@ -1,7 +1,7 @@
-import StyleDictionary, { Named, Transform } from "style-dictionary";
+import type { Transform, TransformedToken } from "style-dictionary/types";
 import { fluidClamp } from "../../utils/fluid";
 
-const isClamp = (token: StyleDictionary.TransformedToken) =>
+const isClamp = (token: TransformedToken) =>
   (token?.$type === "fluidClamp" || token?.type === "fluidClamp") &&
   typeof token.value === "object" &&
   "min" in token.value &&
@@ -18,18 +18,12 @@ type TokenClamp = {
   unit: string;
 };
 
-export const fluidClampTransform: Named<Transform> = {
+export const fluidClampTransform: Transform = {
   name: "fluidClamp",
   type: "value",
   transitive: true,
-  matcher: isClamp,
-  transformer: ({ value }: { value: TokenClamp }) => {
-    return fluidClamp(
-      value.min,
-      value.max,
-      value.viewportMin,
-      value.viewportMax,
-      value.unit
-    );
+  filter: isClamp,
+  transform: ({ value }: { value: TokenClamp }) => {
+    return fluidClamp(value.min, value.max, value.viewportMin, value.viewportMax, value.unit);
   },
 };

--- a/packages/kobber-base/src/styleDictionary/transforms/pxToRem.ts
+++ b/packages/kobber-base/src/styleDictionary/transforms/pxToRem.ts
@@ -1,5 +1,6 @@
 import type { Transform } from "style-dictionary/types";
 
+/** @deprecated Already built in: https://styledictionary.com/reference/hooks/transforms/predefined/#sizepxtorem */
 export const pxToRemTransform: Transform = {
   name: "pxToRem",
   type: "value",

--- a/packages/kobber-base/src/styleDictionary/transforms/pxToRem.ts
+++ b/packages/kobber-base/src/styleDictionary/transforms/pxToRem.ts
@@ -1,11 +1,10 @@
-import { Named, Transform } from "style-dictionary";
+import type { Transform } from "style-dictionary/types";
 
-export const pxToRemTransform: Named<Transform> = {
+export const pxToRemTransform: Transform = {
   name: "pxToRem",
   type: "value",
-  matcher: (token) =>
-    token.path[0] === "primitives" && token.type === "dimension",
-  transformer: (token) => {
+  filter: token => token.path[0] === "primitives" && token.type === "dimension",
+  transform: token => {
     const value = parseFloat(token.value);
     return !isNaN(value) ? `${value / 16}rem` : value;
   },

--- a/packages/kobber-base/src/typography/buildTypography.ts
+++ b/packages/kobber-base/src/typography/buildTypography.ts
@@ -33,7 +33,12 @@ export const buildTypography = (themeConfig: ThemeConfig) => {
   console.info(`✔︎ ${themeTokensDirectory}/typography-tokens.json`);
 
   const plainCss = typographyTokensFlattened
-    .map(item => getTypographyCssClass(["kobber", "typography", ...item.path, item.name].join("-"), item.styles))
+    .map(item =>
+      getTypographyCssClass(
+        ["kobber", "typography", ...item.path, item.fullNameCamelCase?.replace(" ", "-")].join("-"),
+        item.styles,
+      ),
+    )
     .map(trimLineBreaks)
     .join("\n");
 
@@ -41,7 +46,7 @@ export const buildTypography = (themeConfig: ThemeConfig) => {
   console.info(`✔︎ ${themeTokensDirectory}/typography.css`);
 
   const moduleCss = typographyTokensFlattened
-    .map(item => getTypographyCssClass(item.fullNameCamelCase, item.styles))
+    .map(item => getTypographyCssClass(item.fullNameCamelCase?.replace(" ", "-"), item.styles))
     .map(trimLineBreaks)
     .join("\n");
 

--- a/packages/kobber-base/src/utils/cleanFolder.ts
+++ b/packages/kobber-base/src/utils/cleanFolder.ts
@@ -1,9 +1,9 @@
 import * as fs from "fs";
 import { themeDirectory } from "../types";
 
-export const cleanFolder = () => {
+export const cleanThemeDirectory = () => {
   if (fs.existsSync(themeDirectory)) {
-    fs.rmdirSync(themeDirectory, { recursive: true });
+    fs.rmSync(themeDirectory, { recursive: true });
   } else {
     fs.mkdirSync(themeDirectory);
   }

--- a/packages/kobber-base/src/utils/cleanFolder.ts
+++ b/packages/kobber-base/src/utils/cleanFolder.ts
@@ -1,0 +1,10 @@
+import * as fs from "fs";
+import { themeDirectory } from "../types";
+
+export const cleanFolder = () => {
+  if (fs.existsSync(themeDirectory)) {
+    fs.rmdirSync(themeDirectory, { recursive: true });
+  } else {
+    fs.mkdirSync(themeDirectory);
+  }
+};

--- a/packages/kobber-base/tests/buildThemeTokens.test.ts
+++ b/packages/kobber-base/tests/buildThemeTokens.test.ts
@@ -1,11 +1,11 @@
+import type { Config } from "style-dictionary/types";
 import * as fs from "fs";
-import StyleDictionary from "style-dictionary";
 import { ThemeConfig, themeDirectory } from "../src/types";
 import { buildThemeTokens } from "../src/styleDictionary/buildThemeTokens";
 
 /** Assert various steps of token build */
-export const buildThemeTokensTest = (tokensFromFigma: any, themeConfig: ThemeConfig) => {
-  const { allTokens, styleDictionaryConfig } = buildThemeTokens(tokensFromFigma, themeConfig);
+export const buildThemeTokensTest = async (tokensFromFigma: any, themeConfig: ThemeConfig) => {
+  const { allTokens, styleDictionaryConfig } = await buildThemeTokens(tokensFromFigma, themeConfig, false);
 
   assertSanitized(allTokens, themeConfig);
 
@@ -22,7 +22,7 @@ const assertSanitized = (tokensFromFigmaSanitized: any, themeConfig: ThemeConfig
   }
 };
 
-const assertBuildComplete = (styleDictionaryConfig: StyleDictionary.Config, themeConfig: ThemeConfig) => {
+const assertBuildComplete = (styleDictionaryConfig: Config, themeConfig: ThemeConfig) => {
   const tokenDirectory = `${themeDirectory}/${themeConfig.themeName}`;
   if (!fs.existsSync(`${tokenDirectory}/tokens.json`)) {
     console.error(`Build failed. Files does not exist in ${tokenDirectory}`);

--- a/packages/kobber-base/tests/index.ts
+++ b/packages/kobber-base/tests/index.ts
@@ -3,9 +3,6 @@ import { buildTypographyTest } from "./buildTypography.test";
 import { tokensFromFigma } from "../tokens-from-figma";
 import simpleTokens from "./test-data-simple.json";
 import { ThemeConfig } from "../src/types";
-import { cleanThemeDirectory } from "../src/utils/cleanFolder";
-
-cleanThemeDirectory();
 
 const simpleTest: ThemeConfig = {
   figmaMode: "mode 1",

--- a/packages/kobber-base/tests/index.ts
+++ b/packages/kobber-base/tests/index.ts
@@ -3,13 +3,16 @@ import { buildTypographyTest } from "./buildTypography.test";
 import { tokensFromFigma } from "../tokens-from-figma";
 import simpleTokens from "./test-data-simple.json";
 import { ThemeConfig } from "../src/types";
+import { cleanThemeDirectory } from "../src/utils/cleanFolder";
+
+cleanThemeDirectory();
 
 const simpleTest: ThemeConfig = {
   figmaMode: "mode 1",
   themeName: "test-simple",
 };
 
-buildThemeTokensTest(simpleTokens, simpleTest);
+await buildThemeTokensTest(simpleTokens, simpleTest);
 buildTypographyTest(simpleTest);
 
 const fullTest: ThemeConfig = {
@@ -17,5 +20,5 @@ const fullTest: ThemeConfig = {
   themeName: "test-full",
 };
 
-buildThemeTokensTest(tokensFromFigma, fullTest);
+await buildThemeTokensTest(tokensFromFigma, fullTest);
 buildTypographyTest(fullTest);

--- a/packages/kobber-components/src/utils/theme-context.ts
+++ b/packages/kobber-components/src/utils/theme-context.ts
@@ -24,6 +24,7 @@ export class ThemeContextProvider extends LitElement {
   update(changedProperties: PropertyValueMap<ThemeContextProvider> | Map<PropertyKey, unknown>): void {
     if (changedProperties.has("themeId")) {
       this.theme = this.themes.find(theme => theme.id === this.themeId) || this.themes[0];
+      this.classList.add(this.theme.id);
     }
     super.update(changedProperties);
   }

--- a/packages/kobber-components/src/wiki-accordion/Accordion.styles.ts
+++ b/packages/kobber-components/src/wiki-accordion/Accordion.styles.ts
@@ -1,0 +1,18 @@
+import { component } from "@gyldendal/kobber-base/themes/default/tokens.css-variables";
+import { css, unsafeCSS } from "lit";
+
+export const accordionStyles = css`
+  .accordion {
+    border-radius: var(${unsafeCSS(component["wiki-list-item"].container.border.radius)});
+  }
+
+  .accordion-content {
+    overflow: hidden;
+    transition: max-height 0.2s ease-out;
+    max-height: 1000px;
+  }
+
+  .accordion-content[aria-hidden="true"] {
+    max-height: 0;
+  }
+`;

--- a/packages/kobber-components/src/wiki-accordion/Accordion.ts
+++ b/packages/kobber-components/src/wiki-accordion/Accordion.ts
@@ -1,11 +1,9 @@
-import { LitElement, css, html } from "lit";
+import { CSSResultGroup, LitElement, html } from "lit";
 import { customElement, property, query } from "lit/decorators.js";
 import "../wiki-list/List";
 import "../wiki-list/ListItem";
-import { consume } from "@lit/context";
-import { Theme } from "../utils/theme-context.types";
-import { themeContext } from "../utils/theme-context";
-import KobberElement from "../base/kobber-element";
+import componentStyles from "../base/styles/component.styles";
+import { accordionStyles } from "./Accordion.styles";
 
 export const customElementName = "kobber-wiki-accordion";
 
@@ -17,9 +15,8 @@ type HeadingLevel = 1 | 2 | 3 | 4 | 5 | 6;
  * @todo Add "exclusive" option which makes sure only one accordion is open at a time. See {@link https://developer.mozilla.org/en-US/blog/html-details-exclusive-accordions/#using_details_name_to_create_exclusive_accordions|example}.
  */
 @customElement(customElementName)
-export class Accordion extends KobberElement {
-  @consume({ context: themeContext, subscribe: true })
-  theme?: Theme;
+export class Accordion extends LitElement {
+  static styles: CSSResultGroup = [componentStyles, accordionStyles];
 
   @property()
   expanded = false;
@@ -45,10 +42,6 @@ export class Accordion extends KobberElement {
   override render() {
     const dateNowAsElementId = new Date().toISOString();
     return html`
-      <style>
-        ${this.themedStyles()}
-      </style>
-
       <div class="accordion" tabindex="-1">
         <div role="heading" aria-level="${this.headingLevel}">
           <kobber-wiki-list-item
@@ -72,24 +65,4 @@ export class Accordion extends KobberElement {
       </div>
     `;
   }
-
-  themedStyles = () => {
-    const component = this.tokens().component["wiki-list-item"];
-
-    return css`
-      .accordion {
-        border-radius: ${component.container.border.radius}px;
-      }
-
-      .accordion-content {
-        overflow: hidden;
-        transition: max-height 0.2s ease-out;
-        max-height: 1000px;
-      }
-
-      .accordion-content[aria-hidden="true"] {
-        max-height: 0;
-      }
-    `;
-  };
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1575,6 +1575,46 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@bundled-es-modules/deepmerge@npm:^4.3.1":
+  version: 4.3.1
+  resolution: "@bundled-es-modules/deepmerge@npm:4.3.1"
+  dependencies:
+    deepmerge: "npm:^4.3.1"
+  checksum: 10c0/50493fb741d588aa358edc5e844cbf31493cb64aca0a5ca0d33d73f61eb9eb853f7038074429343afbe199e614a6be8400abfd31909f9e5f14a53a4cff39b894
+  languageName: node
+  linkType: hard
+
+"@bundled-es-modules/glob@npm:^10.4.2":
+  version: 10.4.2
+  resolution: "@bundled-es-modules/glob@npm:10.4.2"
+  dependencies:
+    buffer: "npm:^6.0.3"
+    events: "npm:^3.3.0"
+    glob: "npm:^10.4.2"
+    patch-package: "npm:^8.0.0"
+    path: "npm:^0.12.7"
+    stream: "npm:^0.0.3"
+    string_decoder: "npm:^1.3.0"
+    url: "npm:^0.11.3"
+  checksum: 10c0/0c61907efb170750c69c7a6953d613bcbffdefca5ced668c0579baf46e28232793fb6e2ac3b736dd937f750572ef5a17483c417060df43e4be30dc4c8567aaba
+  languageName: node
+  linkType: hard
+
+"@bundled-es-modules/memfs@npm:^4.9.4":
+  version: 4.9.4
+  resolution: "@bundled-es-modules/memfs@npm:4.9.4"
+  dependencies:
+    assert: "npm:^2.0.0"
+    buffer: "npm:^6.0.3"
+    events: "npm:^3.3.0"
+    memfs: "npm:^4.9.3"
+    path: "npm:^0.12.7"
+    stream: "npm:^0.0.3"
+    util: "npm:^0.12.5"
+  checksum: 10c0/e3548c14379183fb74aa9a94407c1cdb8587320216fb557c0af7277d2dccf23f10a2edf8726e99f878758730c0c8d71524f77e19b26660a067b01d9afa07c891
+  languageName: node
+  linkType: hard
+
 "@changesets/apply-release-plan@npm:^7.0.4":
   version: 7.0.4
   resolution: "@changesets/apply-release-plan@npm:7.0.4"
@@ -2883,7 +2923,7 @@ __metadata:
   resolution: "@gyldendal/kobber-base@workspace:packages/kobber-base"
   dependencies:
     "@types/node": "npm:^20.9.0"
-    style-dictionary: "npm:^3.9.0"
+    style-dictionary: "npm:^4.3.0"
     tsx: "npm:^4.6.2"
     typescript: "npm:^5.6.3"
   languageName: unknown
@@ -3271,6 +3311,38 @@ __metadata:
     "@jridgewell/resolve-uri": "npm:^3.1.0"
     "@jridgewell/sourcemap-codec": "npm:^1.4.14"
   checksum: 10c0/3d1ce6ebc69df9682a5a8896b414c6537e428a1d68b02fcc8363b04284a8ca0df04d0ee3013132252ab14f2527bc13bea6526a912ecb5658f0e39fd2860b4df4
+  languageName: node
+  linkType: hard
+
+"@jsonjoy.com/base64@npm:^1.1.1":
+  version: 1.1.2
+  resolution: "@jsonjoy.com/base64@npm:1.1.2"
+  peerDependencies:
+    tslib: 2
+  checksum: 10c0/88717945f66dc89bf58ce75624c99fe6a5c9a0c8614e26d03e406447b28abff80c69fb37dabe5aafef1862cf315071ae66e5c85f6018b437d95f8d13d235e6eb
+  languageName: node
+  linkType: hard
+
+"@jsonjoy.com/json-pack@npm:^1.0.3":
+  version: 1.1.1
+  resolution: "@jsonjoy.com/json-pack@npm:1.1.1"
+  dependencies:
+    "@jsonjoy.com/base64": "npm:^1.1.1"
+    "@jsonjoy.com/util": "npm:^1.1.2"
+    hyperdyperid: "npm:^1.2.0"
+    thingies: "npm:^1.20.0"
+  peerDependencies:
+    tslib: 2
+  checksum: 10c0/fd0d8baa0c8eba536924540717901e0d7eed742576991033cceeb32dcce801ee0a4318cf6eb40b444c9e78f69ddbd4f38b9eb0041e9e54c17e7b6d1219b12e1d
+  languageName: node
+  linkType: hard
+
+"@jsonjoy.com/util@npm:^1.1.2, @jsonjoy.com/util@npm:^1.3.0":
+  version: 1.5.0
+  resolution: "@jsonjoy.com/util@npm:1.5.0"
+  peerDependencies:
+    tslib: 2
+  checksum: 10c0/0065ae12c4108d8aede01a479c8d2b5a39bce99e9a449d235befc753f57e8385d9c1115720529f26597840b7398d512898155423d9859fd638319fb0c827365d
   languageName: node
   linkType: hard
 
@@ -8018,6 +8090,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@yarnpkg/lockfile@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "@yarnpkg/lockfile@npm:1.1.0"
+  checksum: 10c0/0bfa50a3d756623d1f3409bc23f225a1d069424dbc77c6fd2f14fb377390cd57ec703dc70286e081c564be9051ead9ba85d81d66a3e68eeb6eb506d4e0c0fbda
+  languageName: node
+  linkType: hard
+
+"@zip.js/zip.js@npm:^2.7.44":
+  version: 2.7.54
+  resolution: "@zip.js/zip.js@npm:2.7.54"
+  checksum: 10c0/2cc19d5dc3bd665cbaa5e487dda506ed5bfb08c3f63d5ad147864c055f3ca7532a00b4f12b378e811b6f12185739d5e2c78943e796ca713d51a5682cb7836d94
+  languageName: node
+  linkType: hard
+
 "abbrev@npm:^2.0.0":
   version: 2.0.0
   resolution: "abbrev@npm:2.0.0"
@@ -8409,7 +8495,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"assert@npm:^2.1.0":
+"assert@npm:^2.0.0, assert@npm:^2.1.0":
   version: 2.1.0
   resolution: "assert@npm:2.1.0"
   dependencies:
@@ -8490,6 +8576,13 @@ __metadata:
   version: 0.4.0
   resolution: "asynckit@npm:0.4.0"
   checksum: 10c0/d73e2ddf20c4eb9337e1b3df1a0f6159481050a5de457c55b14ea2e5cb6d90bb69e004c9af54737a5ee0917fcf2c9e25de67777bbe58261847846066ba75bc9d
+  languageName: node
+  linkType: hard
+
+"at-least-node@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "at-least-node@npm:1.0.0"
+  checksum: 10c0/4c058baf6df1bc5a1697cf182e2029c58cd99975288a13f9e70068ef5d6f4e1f1fd7c4d2c3c4912eae44797d1725be9700995736deca441b39f3e66d8dee97ef
   languageName: node
   linkType: hard
 
@@ -8863,6 +8956,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"buffer@npm:^6.0.3":
+  version: 6.0.3
+  resolution: "buffer@npm:6.0.3"
+  dependencies:
+    base64-js: "npm:^1.3.1"
+    ieee754: "npm:^1.2.1"
+  checksum: 10c0/2a905fbbcde73cc5d8bd18d1caa23715d5f83a5935867c2329f0ac06104204ba7947be098fe1317fbd8830e26090ff8e764f08cd14fefc977bb248c3487bcbd0
+  languageName: node
+  linkType: hard
+
 "builtin-modules@npm:^3.3.0":
   version: 3.3.0
   resolution: "builtin-modules@npm:3.3.0"
@@ -8972,16 +9075,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"camel-case@npm:^4.1.2":
-  version: 4.1.2
-  resolution: "camel-case@npm:4.1.2"
-  dependencies:
-    pascal-case: "npm:^3.1.2"
-    tslib: "npm:^2.0.3"
-  checksum: 10c0/bf9eefaee1f20edbed2e9a442a226793bc72336e2b99e5e48c6b7252b6f70b080fc46d8246ab91939e2af91c36cdd422e0af35161e58dd089590f302f8f64c8a
-  languageName: node
-  linkType: hard
-
 "camelcase-css@npm:^2.0.1":
   version: 2.0.1
   resolution: "camelcase-css@npm:2.0.1"
@@ -9014,17 +9107,6 @@ __metadata:
   version: 1.0.30001651
   resolution: "caniuse-lite@npm:1.0.30001651"
   checksum: 10c0/7821278952a6dbd17358e5d08083d258f092e2a530f5bc1840657cb140fbbc5ec44293bc888258c44a18a9570cde149ed05819ac8320b9710cf22f699891e6ad
-  languageName: node
-  linkType: hard
-
-"capital-case@npm:^1.0.4":
-  version: 1.0.4
-  resolution: "capital-case@npm:1.0.4"
-  dependencies:
-    no-case: "npm:^3.0.4"
-    tslib: "npm:^2.0.3"
-    upper-case-first: "npm:^2.0.2"
-  checksum: 10c0/6a034af73401f6e55d91ea35c190bbf8bda21714d4ea8bb8f1799311d123410a80f0875db4e3236dc3f97d74231ff4bf1c8783f2be13d7733c7d990c57387281
   languageName: node
   linkType: hard
 
@@ -9065,23 +9147,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"change-case@npm:^4.1.2":
-  version: 4.1.2
-  resolution: "change-case@npm:4.1.2"
-  dependencies:
-    camel-case: "npm:^4.1.2"
-    capital-case: "npm:^1.0.4"
-    constant-case: "npm:^3.0.4"
-    dot-case: "npm:^3.0.4"
-    header-case: "npm:^2.0.4"
-    no-case: "npm:^3.0.4"
-    param-case: "npm:^3.0.4"
-    pascal-case: "npm:^3.1.2"
-    path-case: "npm:^3.0.4"
-    sentence-case: "npm:^3.0.4"
-    snake-case: "npm:^3.0.4"
-    tslib: "npm:^2.0.3"
-  checksum: 10c0/95a6e48563cd393241ce18470c7310a8a050304a64b63addac487560ab039ce42b099673d1d293cc10652324d92060de11b5d918179fe3b5af2ee521fb03ca58
+"chalk@npm:^5.3.0":
+  version: 5.3.0
+  resolution: "chalk@npm:5.3.0"
+  checksum: 10c0/8297d436b2c0f95801103ff2ef67268d362021b8210daf8ddbe349695333eb3610a71122172ff3b0272f1ef2cf7cc2c41fdaa4715f52e49ffe04c56340feed09
+  languageName: node
+  linkType: hard
+
+"change-case@npm:^5.3.0":
+  version: 5.4.4
+  resolution: "change-case@npm:5.4.4"
+  checksum: 10c0/2a9c2b9c9ad6ab2491105aaf506db1a9acaf543a18967798dcce20926c6a173aa63266cb6189f3086e3c14bf7ae1f8ea4f96ecc466fcd582310efa00372f3734
   languageName: node
   linkType: hard
 
@@ -9530,6 +9606,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"component-emitter@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "component-emitter@npm:2.0.0"
+  checksum: 10c0/65dfaf787ea49eb48f0ffec766bda7ec67e8dbeb3b406f08724dcae842e0aa274731fcccb9280b77d2b41693061731a9080b60d276020246a146544cd9900b83
+  languageName: node
+  linkType: hard
+
 "composed-offset-position@npm:^0.0.4":
   version: 0.0.4
   resolution: "composed-offset-position@npm:0.0.4"
@@ -9603,17 +9686,6 @@ __metadata:
   version: 3.2.3
   resolution: "consola@npm:3.2.3"
   checksum: 10c0/c606220524ec88a05bb1baf557e9e0e04a0c08a9c35d7a08652d99de195c4ddcb6572040a7df57a18ff38bbc13ce9880ad032d56630cef27bef72768ef0ac078
-  languageName: node
-  linkType: hard
-
-"constant-case@npm:^3.0.4":
-  version: 3.0.4
-  resolution: "constant-case@npm:3.0.4"
-  dependencies:
-    no-case: "npm:^3.0.4"
-    tslib: "npm:^2.0.3"
-    upper-case: "npm:^2.0.2"
-  checksum: 10c0/91d54f18341fcc491ae66d1086642b0cc564be3e08984d7b7042f8b0a721c8115922f7f11d6a09f13ed96ff326eabae11f9d1eb0335fa9d8b6e39e4df096010e
   languageName: node
   linkType: hard
 
@@ -10263,16 +10335,6 @@ __metadata:
     domelementtype: "npm:^2.2.0"
     domhandler: "npm:^4.2.0"
   checksum: 10c0/d58e2ae01922f0dd55894e61d18119924d88091837887bf1438f2327f32c65eb76426bd9384f81e7d6dcfb048e0f83c19b222ad7101176ad68cdc9c695b563db
-  languageName: node
-  linkType: hard
-
-"dot-case@npm:^3.0.4":
-  version: 3.0.4
-  resolution: "dot-case@npm:3.0.4"
-  dependencies:
-    no-case: "npm:^3.0.4"
-    tslib: "npm:^2.0.3"
-  checksum: 10c0/5b859ea65097a7ea870e2c91b5768b72ddf7fa947223fd29e167bcdff58fe731d941c48e47a38ec8aa8e43044c8fbd15cd8fa21689a526bc34b6548197cd5b05
   languageName: node
   linkType: hard
 
@@ -11828,6 +11890,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"events@npm:^3.3.0":
+  version: 3.3.0
+  resolution: "events@npm:3.3.0"
+  checksum: 10c0/d6b6f2adbccbcda74ddbab52ed07db727ef52e31a61ed26db9feb7dc62af7fc8e060defa65e5f8af9449b86b52cc1a1f6a79f2eafcf4e62add2b7a1fa4a432f6
+  languageName: node
+  linkType: hard
+
 "execa@npm:^5.0.0, execa@npm:^5.1.1":
   version: 5.1.1
   resolution: "execa@npm:5.1.1"
@@ -12219,6 +12288,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"find-yarn-workspace-root@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "find-yarn-workspace-root@npm:2.0.0"
+  dependencies:
+    micromatch: "npm:^4.0.2"
+  checksum: 10c0/b0d3843013fbdaf4e57140e0165889d09fa61745c9e85da2af86e54974f4cc9f1967e40f0d8fc36a79d53091f0829c651d06607d552582e53976f3cd8f4e5689
+  languageName: node
+  linkType: hard
+
 "flat-cache@npm:^3.0.4":
   version: 3.2.0
   resolution: "flat-cache@npm:3.2.0"
@@ -12337,17 +12415,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fs-extra@npm:^10.0.0":
-  version: 10.1.0
-  resolution: "fs-extra@npm:10.1.0"
-  dependencies:
-    graceful-fs: "npm:^4.2.0"
-    jsonfile: "npm:^6.0.1"
-    universalify: "npm:^2.0.0"
-  checksum: 10c0/5f579466e7109719d162a9249abbeffe7f426eb133ea486e020b89bc6d67a741134076bf439983f2eb79276ceaf6bd7b7c1e43c3fd67fe889863e69072fb0a5e
-  languageName: node
-  linkType: hard
-
 "fs-extra@npm:^11.1.0, fs-extra@npm:^11.2.0":
   version: 11.2.0
   resolution: "fs-extra@npm:11.2.0"
@@ -12378,6 +12445,18 @@ __metadata:
     jsonfile: "npm:^4.0.0"
     universalify: "npm:^0.1.0"
   checksum: 10c0/259f7b814d9e50d686899550c4f9ded85c46c643f7fe19be69504888e007fcbc08f306fae8ec495b8b998635e997c9e3e175ff2eeed230524ef1c1684cc96423
+  languageName: node
+  linkType: hard
+
+"fs-extra@npm:^9.0.0":
+  version: 9.1.0
+  resolution: "fs-extra@npm:9.1.0"
+  dependencies:
+    at-least-node: "npm:^1.0.0"
+    graceful-fs: "npm:^4.2.0"
+    jsonfile: "npm:^6.0.1"
+    universalify: "npm:^2.0.0"
+  checksum: 10c0/9b808bd884beff5cb940773018179a6b94a966381d005479f00adda6b44e5e3d4abf765135773d849cc27efe68c349e4a7b86acd7d3306d5932c14f3a4b17a92
   languageName: node
   linkType: hard
 
@@ -12665,7 +12744,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"glob@npm:^10.0.0, glob@npm:^10.2.2, glob@npm:^10.3.10":
+"glob@npm:^10.0.0, glob@npm:^10.2.2, glob@npm:^10.3.10, glob@npm:^10.4.2":
   version: 10.4.5
   resolution: "glob@npm:10.4.5"
   dependencies:
@@ -12894,16 +12973,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"header-case@npm:^2.0.4":
-  version: 2.0.4
-  resolution: "header-case@npm:2.0.4"
-  dependencies:
-    capital-case: "npm:^1.0.4"
-    tslib: "npm:^2.0.3"
-  checksum: 10c0/c9f295d9d8e38fa50679281fd70d80726962256e888a76c8e72e526453da7a1832dcb427caa716c1ad5d79841d4537301b90156fa30298fefd3d68f4ea2181bb
-  languageName: node
-  linkType: hard
-
 "hosted-git-info@npm:^2.1.4":
   version: 2.8.9
   resolution: "hosted-git-info@npm:2.8.9"
@@ -13040,6 +13109,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"hyperdyperid@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "hyperdyperid@npm:1.2.0"
+  checksum: 10c0/885ba3177c7181d315a856ee9c0005ff8eb5dcb1ce9e9d61be70987895d934d84686c37c981cceeb53216d4c9c15c1cc25f1804e84cc6a74a16993c5d7fd0893
+  languageName: node
+  linkType: hard
+
 "iconv-lite@npm:0.4.24, iconv-lite@npm:^0.4.24":
   version: 0.4.24
   resolution: "iconv-lite@npm:0.4.24"
@@ -13058,7 +13134,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ieee754@npm:^1.1.13":
+"ieee754@npm:^1.1.13, ieee754@npm:^1.2.1":
   version: 1.2.1
   resolution: "ieee754@npm:1.2.1"
   checksum: 10c0/b0782ef5e0935b9f12883a2e2aa37baa75da6e66ce6515c168697b42160807d9330de9a32ec1ed73149aea02e0d822e572bca6f1e22bdcbd2149e13b050b17bb
@@ -13574,7 +13650,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-plain-obj@npm:^4.0.0":
+"is-plain-obj@npm:^4.0.0, is-plain-obj@npm:^4.1.0":
   version: 4.1.0
   resolution: "is-plain-obj@npm:4.1.0"
   checksum: 10c0/32130d651d71d9564dc88ba7e6fda0e91a1010a3694648e9f4f47bb6080438140696d3e3e15c741411d712e47ac9edc1a8a9de1fe76f3487b0d90be06ac9975e
@@ -13729,7 +13805,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-wsl@npm:^2.2.0":
+"is-wsl@npm:^2.1.1, is-wsl@npm:^2.2.0":
   version: 2.2.0
   resolution: "is-wsl@npm:2.2.0"
   dependencies:
@@ -14149,6 +14225,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"json-stable-stringify@npm:^1.0.2":
+  version: 1.1.1
+  resolution: "json-stable-stringify@npm:1.1.1"
+  dependencies:
+    call-bind: "npm:^1.0.5"
+    isarray: "npm:^2.0.5"
+    jsonify: "npm:^0.0.1"
+    object-keys: "npm:^1.1.1"
+  checksum: 10c0/3801e3eeccbd030afb970f54bea690a079cfea7d9ed206a1b17ca9367f4b7772c764bf77a48f03e56b50e5f7ee7d11c52339fe20d8d7ccead003e4ca69e4cfde
+  languageName: node
+  linkType: hard
+
 "json5@npm:^1.0.2":
   version: 1.0.2
   resolution: "json5@npm:1.0.2"
@@ -14169,7 +14257,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jsonc-parser@npm:^3.0.0, jsonc-parser@npm:^3.2.0":
+"jsonc-parser@npm:^3.2.0":
   version: 3.3.1
   resolution: "jsonc-parser@npm:3.3.1"
   checksum: 10c0/269c3ae0a0e4f907a914bf334306c384aabb9929bd8c99f909275ebd5c2d3bc70b9bcd119ad794f339dec9f24b6a4ee9cd5a8ab2e6435e730ad4075388fc2ab6
@@ -14198,6 +14286,13 @@ __metadata:
     graceful-fs:
       optional: true
   checksum: 10c0/4f95b5e8a5622b1e9e8f33c96b7ef3158122f595998114d1e7f03985649ea99cb3cd99ce1ed1831ae94c8c8543ab45ebd044207612f31a56fd08462140e46865
+  languageName: node
+  linkType: hard
+
+"jsonify@npm:^0.0.1":
+  version: 0.0.1
+  resolution: "jsonify@npm:0.0.1"
+  checksum: 10c0/7f5499cdd59a0967ed35bda48b7cec43d850bbc8fb955cdd3a1717bb0efadbe300724d5646de765bb7a99fc1c3ab06eb80d93503c6faaf99b4ff50a3326692f6
   languageName: node
   linkType: hard
 
@@ -14235,6 +14330,15 @@ __metadata:
   version: 6.0.3
   resolution: "kind-of@npm:6.0.3"
   checksum: 10c0/61cdff9623dabf3568b6445e93e31376bee1cdb93f8ba7033d86022c2a9b1791a1d9510e026e6465ebd701a6dd2f7b0808483ad8838341ac52f003f512e0b4c4
+  languageName: node
+  linkType: hard
+
+"klaw-sync@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "klaw-sync@npm:6.0.0"
+  dependencies:
+    graceful-fs: "npm:^4.1.11"
+  checksum: 10c0/00d8e4c48d0d699b743b3b028e807295ea0b225caf6179f51029e19783a93ad8bb9bccde617d169659fbe99559d73fb35f796214de031d0023c26b906cecd70a
   languageName: node
   linkType: hard
 
@@ -14748,15 +14852,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lower-case@npm:^2.0.2":
-  version: 2.0.2
-  resolution: "lower-case@npm:2.0.2"
-  dependencies:
-    tslib: "npm:^2.0.3"
-  checksum: 10c0/3d925e090315cf7dc1caa358e0477e186ffa23947740e4314a7429b6e62d72742e0bbe7536a5ae56d19d7618ce998aba05caca53c2902bd5742fdca5fc57fd7b
-  languageName: node
-  linkType: hard
-
 "lru-cache@npm:^10.0.1, lru-cache@npm:^10.2.0":
   version: 10.4.3
   resolution: "lru-cache@npm:10.4.3"
@@ -15095,6 +15190,18 @@ __metadata:
   version: 0.3.0
   resolution: "media-typer@npm:0.3.0"
   checksum: 10c0/d160f31246907e79fed398470285f21bafb45a62869dc469b1c8877f3f064f5eabc4bcc122f9479b8b605bc5c76187d7871cf84c4ee3ecd3e487da1993279928
+  languageName: node
+  linkType: hard
+
+"memfs@npm:^4.9.3":
+  version: 4.15.0
+  resolution: "memfs@npm:4.15.0"
+  dependencies:
+    "@jsonjoy.com/json-pack": "npm:^1.0.3"
+    "@jsonjoy.com/util": "npm:^1.3.0"
+    tree-dump: "npm:^1.0.1"
+    tslib: "npm:^2.0.0"
+  checksum: 10c0/be161036983ad517b8a6cb5e4493e6e0f1cc44024bc2135d51d9b28e823bb6a68bb00233900a1e9b93e942e8f581747f432b2224eb26c0045d97f8c84d25bd27
   languageName: node
   linkType: hard
 
@@ -15923,16 +16030,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"no-case@npm:^3.0.4":
-  version: 3.0.4
-  resolution: "no-case@npm:3.0.4"
-  dependencies:
-    lower-case: "npm:^2.0.2"
-    tslib: "npm:^2.0.3"
-  checksum: 10c0/8ef545f0b3f8677c848f86ecbd42ca0ff3cd9dd71c158527b344c69ba14710d816d8489c746b6ca225e7b615108938a0bda0a54706f8c255933703ac1cf8e703
-  languageName: node
-  linkType: hard
-
 "node-dir@npm:^0.1.17":
   version: 0.1.17
   resolution: "node-dir@npm:0.1.17"
@@ -16283,6 +16380,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"open@npm:^7.4.2":
+  version: 7.4.2
+  resolution: "open@npm:7.4.2"
+  dependencies:
+    is-docker: "npm:^2.0.0"
+    is-wsl: "npm:^2.1.1"
+  checksum: 10c0/77573a6a68f7364f3a19a4c80492712720746b63680ee304555112605ead196afe91052bd3c3d165efdf4e9d04d255e87de0d0a77acec11ef47fd5261251813f
+  languageName: node
+  linkType: hard
+
 "open@npm:^8.0.2, open@npm:^8.0.4, open@npm:^8.4.0":
   version: 8.4.2
   resolution: "open@npm:8.4.2"
@@ -16481,16 +16588,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"param-case@npm:^3.0.4":
-  version: 3.0.4
-  resolution: "param-case@npm:3.0.4"
-  dependencies:
-    dot-case: "npm:^3.0.4"
-    tslib: "npm:^2.0.3"
-  checksum: 10c0/ccc053f3019f878eca10e70ec546d92f51a592f762917dafab11c8b532715dcff58356118a6f350976e4ab109e321756f05739643ed0ca94298e82291e6f9e76
-  languageName: node
-  linkType: hard
-
 "parent-module@npm:^1.0.0":
   version: 1.0.1
   resolution: "parent-module@npm:1.0.1"
@@ -16577,23 +16674,28 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pascal-case@npm:^3.1.2":
-  version: 3.1.2
-  resolution: "pascal-case@npm:3.1.2"
+"patch-package@npm:^8.0.0":
+  version: 8.0.0
+  resolution: "patch-package@npm:8.0.0"
   dependencies:
-    no-case: "npm:^3.0.4"
-    tslib: "npm:^2.0.3"
-  checksum: 10c0/05ff7c344809fd272fc5030ae0ee3da8e4e63f36d47a1e0a4855ca59736254192c5a27b5822ed4bae96e54048eec5f6907713cfcfff7cdf7a464eaf7490786d8
-  languageName: node
-  linkType: hard
-
-"path-case@npm:^3.0.4":
-  version: 3.0.4
-  resolution: "path-case@npm:3.0.4"
-  dependencies:
-    dot-case: "npm:^3.0.4"
-    tslib: "npm:^2.0.3"
-  checksum: 10c0/b6b14637228a558793f603aaeb2fcd981e738b8b9319421b713532fba96d75aa94024b9f6b9ae5aa33d86755144a5b36697d28db62ae45527dbd672fcc2cf0b7
+    "@yarnpkg/lockfile": "npm:^1.1.0"
+    chalk: "npm:^4.1.2"
+    ci-info: "npm:^3.7.0"
+    cross-spawn: "npm:^7.0.3"
+    find-yarn-workspace-root: "npm:^2.0.0"
+    fs-extra: "npm:^9.0.0"
+    json-stable-stringify: "npm:^1.0.2"
+    klaw-sync: "npm:^6.0.0"
+    minimist: "npm:^1.2.6"
+    open: "npm:^7.4.2"
+    rimraf: "npm:^2.6.3"
+    semver: "npm:^7.5.3"
+    slash: "npm:^2.0.0"
+    tmp: "npm:^0.0.33"
+    yaml: "npm:^2.2.2"
+  bin:
+    patch-package: index.js
+  checksum: 10c0/690eab0537e953a3fd7d32bb23f0e82f97cd448f8244c3227ed55933611a126f9476397325c06ad2c11d881a19b427a02bd1881bee78d89f1731373fc4fe0fee
   languageName: node
   linkType: hard
 
@@ -16660,6 +16762,23 @@ __metadata:
   version: 4.0.0
   resolution: "path-type@npm:4.0.0"
   checksum: 10c0/666f6973f332f27581371efaf303fd6c272cc43c2057b37aa99e3643158c7e4b2626549555d88626e99ea9e046f82f32e41bbde5f1508547e9a11b149b52387c
+  languageName: node
+  linkType: hard
+
+"path-unified@npm:^0.2.0":
+  version: 0.2.0
+  resolution: "path-unified@npm:0.2.0"
+  checksum: 10c0/5229bbcbb093b1c76e7a8f568dd7d362bae6bd9348099968252aa17b1ffd86ef845d560a6b483bb2e6a3b2c25a5e8288707b03e41b66b2761aa1e2ba67b07d5b
+  languageName: node
+  linkType: hard
+
+"path@npm:^0.12.7":
+  version: 0.12.7
+  resolution: "path@npm:0.12.7"
+  dependencies:
+    process: "npm:^0.11.1"
+    util: "npm:^0.10.3"
+  checksum: 10c0/f795ce5438a988a590c7b6dfd450ec9baa1c391a8be4c2dea48baa6e0f5b199e56cd83b8c9ebf3991b81bea58236d2c32bdafe2c17a2e70c3a2e4c69891ade59
   languageName: node
   linkType: hard
 
@@ -17283,7 +17402,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"process@npm:^0.11.10":
+"process@npm:^0.11.1, process@npm:^0.11.10":
   version: 0.11.10
   resolution: "process@npm:0.11.10"
   checksum: 10c0/40c3ce4b7e6d4b8c3355479df77aeed46f81b279818ccdc500124e6a5ab882c0cc81ff7ea16384873a95a74c4570b01b120f287abbdd4c877931460eca6084b3
@@ -17406,6 +17525,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"punycode@npm:^1.4.1":
+  version: 1.4.1
+  resolution: "punycode@npm:1.4.1"
+  checksum: 10c0/354b743320518aef36f77013be6e15da4db24c2b4f62c5f1eb0529a6ed02fbaf1cb52925785f6ab85a962f2b590d9cd5ad730b70da72b5f180e2556b8bd3ca08
+  languageName: node
+  linkType: hard
+
 "punycode@npm:^2.1.0, punycode@npm:^2.1.1, punycode@npm:^2.3.1":
   version: 2.3.1
   resolution: "punycode@npm:2.3.1"
@@ -17466,6 +17592,15 @@ __metadata:
   dependencies:
     side-channel: "npm:^1.0.6"
   checksum: 10c0/62372cdeec24dc83a9fb240b7533c0fdcf0c5f7e0b83343edd7310f0ab4c8205a5e7c56406531f2e47e1b4878a3821d652be4192c841de5b032ca83619d8f860
+  languageName: node
+  linkType: hard
+
+"qs@npm:^6.12.3":
+  version: 6.13.1
+  resolution: "qs@npm:6.13.1"
+  dependencies:
+    side-channel: "npm:^1.0.6"
+  checksum: 10c0/5ef527c0d62ffca5501322f0832d800ddc78eeb00da3b906f1b260ca0492721f8cdc13ee4b8fd8ac314a6ec37b948798c7b603ccc167e954088df392092f160c
   languageName: node
   linkType: hard
 
@@ -18108,7 +18243,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rimraf@npm:^2.6.1":
+"rimraf@npm:^2.6.1, rimraf@npm:^2.6.3":
   version: 2.7.1
   resolution: "rimraf@npm:2.7.1"
   dependencies:
@@ -18728,17 +18863,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"sentence-case@npm:^3.0.4":
-  version: 3.0.4
-  resolution: "sentence-case@npm:3.0.4"
-  dependencies:
-    no-case: "npm:^3.0.4"
-    tslib: "npm:^2.0.3"
-    upper-case-first: "npm:^2.0.2"
-  checksum: 10c0/9a90527a51300cf5faea7fae0c037728f9ddcff23ac083883774c74d180c0a03c31aab43d5c3347512e8c1b31a0d4712512ec82beb71aa79b85149f9abeb5467
-  languageName: node
-  linkType: hard
-
 "serve-static@npm:1.15.0":
   version: 1.15.0
   resolution: "serve-static@npm:1.15.0"
@@ -18886,6 +19010,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"slash@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "slash@npm:2.0.0"
+  checksum: 10c0/f83dbd3cb62c41bb8fcbbc6bf5473f3234b97fa1d008f571710a9d3757a28c7169e1811cad1554ccb1cc531460b3d221c9a7b37f549398d9a30707f0a5af9193
+  languageName: node
+  linkType: hard
+
 "slash@npm:^3.0.0":
   version: 3.0.0
   resolution: "slash@npm:3.0.0"
@@ -18908,16 +19039,6 @@ __metadata:
   version: 4.2.0
   resolution: "smart-buffer@npm:4.2.0"
   checksum: 10c0/a16775323e1404dd43fabafe7460be13a471e021637bc7889468eb45ce6a6b207261f454e4e530a19500cc962c4cc5348583520843b363f4193cee5c00e1e539
-  languageName: node
-  linkType: hard
-
-"snake-case@npm:^3.0.4":
-  version: 3.0.4
-  resolution: "snake-case@npm:3.0.4"
-  dependencies:
-    dot-case: "npm:^3.0.4"
-    tslib: "npm:^2.0.3"
-  checksum: 10c0/ab19a913969f58f4474fe9f6e8a026c8a2142a01f40b52b79368068343177f818cdfef0b0c6b9558f298782441d5ca8ed5932eb57822439fad791d866e62cecd
   languageName: node
   linkType: hard
 
@@ -19189,6 +19310,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"stream@npm:^0.0.3":
+  version: 0.0.3
+  resolution: "stream@npm:0.0.3"
+  dependencies:
+    component-emitter: "npm:^2.0.0"
+  checksum: 10c0/5d262408583f3d5fed8077b33ad670320d85c6b7c0fb3ab73a9a632fbad0ee36f3c66e6feb5264cb39dbee3a619174fa886b5f69f98217666d0844f6a2f6510b
+  languageName: node
+  linkType: hard
+
 "streamsearch@npm:^1.1.0":
   version: 1.1.0
   resolution: "streamsearch@npm:1.1.0"
@@ -19318,7 +19448,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"string_decoder@npm:^1.1.1":
+"string_decoder@npm:^1.1.1, string_decoder@npm:^1.3.0":
   version: 1.3.0
   resolution: "string_decoder@npm:1.3.0"
   dependencies:
@@ -19401,22 +19531,26 @@ __metadata:
   languageName: node
   linkType: hard
 
-"style-dictionary@npm:^3.9.0":
-  version: 3.9.2
-  resolution: "style-dictionary@npm:3.9.2"
+"style-dictionary@npm:^4.3.0":
+  version: 4.3.0
+  resolution: "style-dictionary@npm:4.3.0"
   dependencies:
-    chalk: "npm:^4.0.0"
-    change-case: "npm:^4.1.2"
+    "@bundled-es-modules/deepmerge": "npm:^4.3.1"
+    "@bundled-es-modules/glob": "npm:^10.4.2"
+    "@bundled-es-modules/memfs": "npm:^4.9.4"
+    "@zip.js/zip.js": "npm:^2.7.44"
+    chalk: "npm:^5.3.0"
+    change-case: "npm:^5.3.0"
     commander: "npm:^8.3.0"
-    fs-extra: "npm:^10.0.0"
-    glob: "npm:^10.3.10"
+    is-plain-obj: "npm:^4.1.0"
     json5: "npm:^2.2.2"
-    jsonc-parser: "npm:^3.0.0"
-    lodash: "npm:^4.17.15"
-    tinycolor2: "npm:^1.4.1"
+    patch-package: "npm:^8.0.0"
+    path-unified: "npm:^0.2.0"
+    prettier: "npm:^3.3.3"
+    tinycolor2: "npm:^1.6.0"
   bin:
-    style-dictionary: bin/style-dictionary
-  checksum: 10c0/639f567e35565ea4e76f1f564b4b7f21208fd7f0bc86230fce9bee474f6add33defe3c2467fb73703e8e9819c29707d5d1628f2569cb69f2561b9e7b7596d434
+    style-dictionary: bin/style-dictionary.js
+  checksum: 10c0/1fceba59fd9b765842d2d45ea7625d572347a1bc3d8f28509223dcd992dacc8730f242b813fd9e19f6e6c9fb22866776cd05943b256426108a0fd735705d021d
   languageName: node
   linkType: hard
 
@@ -19954,6 +20088,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"thingies@npm:^1.20.0":
+  version: 1.21.0
+  resolution: "thingies@npm:1.21.0"
+  peerDependencies:
+    tslib: ^2
+  checksum: 10c0/7570ee855aecb73185a672ecf3eb1c287a6512bf5476449388433b2d4debcf78100bc8bfd439b0edd38d2bc3bfb8341de5ce85b8557dec66d0f27b962c9a8bc1
+  languageName: node
+  linkType: hard
+
 "through2@npm:^2.0.3":
   version: 2.0.5
   resolution: "through2@npm:2.0.5"
@@ -19978,7 +20121,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tinycolor2@npm:^1.4.1":
+"tinycolor2@npm:^1.6.0":
   version: 1.6.0
   resolution: "tinycolor2@npm:1.6.0"
   checksum: 10c0/9aa79a36ba2c2a87cb221453465cabacd04b9e35f9694373e846fdc78b1c768110f81e581ea41440106c0f24d9a023891d0887e8075885e790ac40eb0e74a5c1
@@ -20095,6 +20238,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tree-dump@npm:^1.0.1":
+  version: 1.0.2
+  resolution: "tree-dump@npm:1.0.2"
+  peerDependencies:
+    tslib: 2
+  checksum: 10c0/d1d180764e9c691b28332dbd74226c6b6af361dfb1e134bb11e60e17cb11c215894adee50ffc578da5dcf546006693947be8b6665eb1269b56e2f534926f1c1f
+  languageName: node
+  linkType: hard
+
 "tree-kill@npm:^1.2.2":
   version: 1.2.2
   resolution: "tree-kill@npm:1.2.2"
@@ -20160,7 +20312,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tslib@npm:^2.0.0, tslib@npm:^2.0.1, tslib@npm:^2.0.3, tslib@npm:^2.1.0, tslib@npm:^2.4.0, tslib@npm:^2.6.1, tslib@npm:^2.6.2":
+"tslib@npm:^2.0.0, tslib@npm:^2.0.1, tslib@npm:^2.1.0, tslib@npm:^2.4.0, tslib@npm:^2.6.1, tslib@npm:^2.6.2":
   version: 2.6.3
   resolution: "tslib@npm:2.6.3"
   checksum: 10c0/2598aef53d9dbe711af75522464b2104724d6467b26a60f2bdac8297d2b5f1f6b86a71f61717384aa8fd897240467aaa7bcc36a0700a0faf751293d1331db39a
@@ -20894,24 +21046,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"upper-case-first@npm:^2.0.2":
-  version: 2.0.2
-  resolution: "upper-case-first@npm:2.0.2"
-  dependencies:
-    tslib: "npm:^2.0.3"
-  checksum: 10c0/ccad6a0b143310ebfba2b5841f30bef71246297385f1329c022c902b2b5fc5aee009faf1ac9da5ab3ba7f615b88f5dc1cd80461b18a8f38cb1d4c3eb92538ea9
-  languageName: node
-  linkType: hard
-
-"upper-case@npm:^2.0.2":
-  version: 2.0.2
-  resolution: "upper-case@npm:2.0.2"
-  dependencies:
-    tslib: "npm:^2.0.3"
-  checksum: 10c0/5ac176c9d3757abb71400df167f9abb46d63152d5797c630d1a9f083fbabd89711fb4b3dc6de06ff0138fe8946fa5b8518b4fcdae9ca8a3e341417075beae069
-  languageName: node
-  linkType: hard
-
 "uri-js@npm:^4.2.2":
   version: 4.4.1
   resolution: "uri-js@npm:4.4.1"
@@ -20928,6 +21062,16 @@ __metadata:
     querystringify: "npm:^2.1.1"
     requires-port: "npm:^1.0.0"
   checksum: 10c0/bd5aa9389f896974beb851c112f63b466505a04b4807cea2e5a3b7092f6fbb75316f0491ea84e44f66fed55f1b440df5195d7e3a8203f64fcefa19d182f5be87
+  languageName: node
+  linkType: hard
+
+"url@npm:^0.11.3":
+  version: 0.11.4
+  resolution: "url@npm:0.11.4"
+  dependencies:
+    punycode: "npm:^1.4.1"
+    qs: "npm:^6.12.3"
+  checksum: 10c0/cc93405ae4a9b97a2aa60ca67f1cb1481c0221cb4725a7341d149be5e2f9cfda26fd432d64dbbec693d16593b68b8a46aad8e5eab21f814932134c9d8620c662
   languageName: node
   linkType: hard
 
@@ -20992,6 +21136,15 @@ __metadata:
   version: 1.0.2
   resolution: "util-deprecate@npm:1.0.2"
   checksum: 10c0/41a5bdd214df2f6c3ecf8622745e4a366c4adced864bc3c833739791aeeeb1838119af7daed4ba36428114b5c67dcda034a79c882e97e43c03e66a4dd7389942
+  languageName: node
+  linkType: hard
+
+"util@npm:^0.10.3":
+  version: 0.10.4
+  resolution: "util@npm:0.10.4"
+  dependencies:
+    inherits: "npm:2.0.3"
+  checksum: 10c0/d29f6893e406b63b088ce9924da03201df89b31490d4d011f1c07a386ea4b3dbe907464c274023c237da470258e1805d806c7e4009a5974cd6b1d474b675852a
   languageName: node
   linkType: hard
 
@@ -21664,6 +21817,15 @@ __metadata:
   bin:
     yaml: bin.mjs
   checksum: 10c0/771a1df083c8217cf04ef49f87244ae2dd7d7457094425e793b8f056159f167602ce172aa32d6bca21f787d24ec724aee3cecde938f6643564117bd151452631
+  languageName: node
+  linkType: hard
+
+"yaml@npm:^2.2.2":
+  version: 2.6.1
+  resolution: "yaml@npm:2.6.1"
+  bin:
+    yaml: bin.mjs
+  checksum: 10c0/aebf07f61c72b38c74d2b60c3a3ccf89ee4da45bcd94b2bfb7899ba07a5257625a7c9f717c65a6fc511563d48001e01deb1d9e55f0133f3e2edf86039c8c1be7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- Created mapping from js to css variables**
- upgrade style dictionary and fix breaking changes
- removed px-to-rem transforms until further notice
- removed scss format (might remove all the outputs we don't use)

** Reason for mapping

```css
/* tokens.css (class used in kobber-context and can be set manually) */
.kobber-theme-default {
  --kobber-foo-bar: 1337px;
}
```
```js
/* tokens.css-variables.js */
{
  foo: {
    bar: "--kobber-foo-bar";
  }
}
```
```js
/* component.ts */
import { css } from "lit";
import { tokens } from "@gyldendal/kobber-base/themes/tokens.css-variables.js";

const styles = css`
  div {
    width: var(${tokens.foo.bar});
  }
`;
```

This enables us to switch themes with only css variables, and still maintain type safety. We're no longer dependent on Lit's context to provide tokens. This makes it possible to theme vanilla custom components as well. 

Performance should also be better because of less context subscriptions, and more static styles instead of injected style elements.