### PR TITLE
Removed img role from background in kobber-scene

### DIFF
--- a/packages/kobber-scene/src/SceneImageBackground.ts
+++ b/packages/kobber-scene/src/SceneImageBackground.ts
@@ -45,7 +45,6 @@ export class SceneImageBackground extends SceneBackground {
 
   connectedCallback() {
     super.connectedCallback();
-    this.role = "img";
   }
 
   private getCropStyles = () => {


### PR DESCRIPTION
Role should be set to img by the consumer only when the image has an alt text