### PR TITLE
Semantic collection is now split in global and regional

### DIFF
--- a/apps/docs/app/(routes)/(landing)/landing.module.css
+++ b/apps/docs/app/(routes)/(landing)/landing.module.css
@@ -1,5 +1,5 @@
 .landing {
   display: flex;
   flex-direction: column;
-  gap: var(--kobber-template-main-gap-max);
+  gap: 2rem;
 }

--- a/apps/docs/app/not-found.tsx
+++ b/apps/docs/app/not-found.tsx
@@ -11,7 +11,7 @@ export default function NotFound() {
         height="400"
         className="rounded-2xl"
       />
-      <h1 className="text-primary-title-m">Ops! Vi fant ikke siden du leter etter</h1>
+      <h1>Ops! Vi fant ikke siden du leter etter</h1>
     </div>
   )
 }

--- a/apps/docs/components/feature-box/feature-box.module.css
+++ b/apps/docs/components/feature-box/feature-box.module.css
@@ -23,7 +23,7 @@
 }
 
 .feature-box-item-label {
-  background-color: var(--kobber-semantics-navigation-color-brightest);
+  background-color: var(--kobber-regional-navigation-color-brightest);
   border-radius: 0.5rem;
   overflow: hidden;
   padding: 0.5rem;

--- a/apps/docs/components/interactive-screen.tsx
+++ b/apps/docs/components/interactive-screen.tsx
@@ -40,11 +40,11 @@ export const InteractiveScreen = ({
         </div>
         <div className="grid gap-24 py-24">
           <div className="grid h-fit w-[251px] max-w-[251px] gap-24 px-24">
-            <h4 className="text-primary-title-s text-[#481125ff]">Egenskaper</h4>
+            <h4 className="text-[#481125ff]">Egenskaper</h4>
             <div className="grid gap-16">{properties(mode)}</div>
           </div>
           <div className="grid h-fit w-[251px] max-w-[251px] gap-12 px-24">
-            <h4 className="text-primary-title-s text-[#481125ff]">Visning</h4>
+            <h4 className="text-[#481125ff]">Visning</h4>
             <RadioGroup defaultValue="light" className="grid gap-16">
               <div className="flex items-center gap-2">
                 <RadioGroupItem

--- a/apps/docs/components/navigation/side-nav.module.css
+++ b/apps/docs/components/navigation/side-nav.module.css
@@ -11,17 +11,17 @@
 
 .side-nav-content {
   border-right: 1px solid var(--kobber-component-divider-background-color-main);
-  padding: var(--kobber-component-wiki-side-menu-container-padding);
+  padding: var(--kobber-component-docs-side-menu-container-padding);
 }
 
 .side-nav-group {
   border-bottom: 1px solid var(--kobber-component-divider-background-color-main);
-  padding-block: var(--kobber-component-wiki-side-menu-container-padding);
+  padding-block: var(--kobber-component-docs-side-menu-container-padding);
 }
 
 .side-nav-list-with-divider {
   & > *:not(:last-child) {
     border-bottom: 1px solid var(--kobber-component-divider-background-color-main);
-    padding-bottom: var(--kobber-component-wiki-side-menu-container-padding);
+    padding-bottom: var(--kobber-component-docs-side-menu-container-padding);
   }
 }

--- a/apps/docs/components/navigation/small-screen-nav.module.css
+++ b/apps/docs/components/navigation/small-screen-nav.module.css
@@ -4,7 +4,7 @@
 
 .small-screen-nav-overlay {
   --navbar-height: calc(
-    2 * var(--kobber-component-wiki-navbar-container-padding-block) +
+    2 * var(--kobber-component-docs-navbar-container-padding-block) +
       var(--kobber-component-button-container-size-height)
   );
 
@@ -15,14 +15,14 @@
 
   display: flex;
   flex-direction: column;
-  background-color: var(--kobber-component-wiki-navbar-background-color-main);
+  background-color: var(--kobber-component-docs-navbar-background-color-main);
   z-index: 900;
   overflow-y: auto;
 }
 
 .small-screen-nav-overlay-back-button {
   opacity: 0.8;
-  padding-block: var(--kobber-component-wiki-navbar-container-padding-block);
+  padding-block: var(--kobber-component-docs-navbar-container-padding-block);
 }
 
 .small-screen-nav-overlay-login-button {
@@ -33,8 +33,8 @@
   display: flex;
   flex-direction: column;
   gap: 2rem;
-  padding-block: var(--kobber-component-wiki-navbar-container-padding-block);
-  background-color: var(--kobber-component-wiki-navbar-background-color-main);
+  padding-block: var(--kobber-component-docs-navbar-container-padding-block);
+  background-color: var(--kobber-component-docs-navbar-background-color-main);
 }
 
 .small-screen-nav-overlay-link-list-inner {

--- a/apps/docs/components/navigation/top-nav.module.css
+++ b/apps/docs/components/navigation/top-nav.module.css
@@ -7,9 +7,9 @@
   grid-template-columns: auto 1fr;
   gap: 1rem;
   align-items: center;
-  padding-block: var(--kobber-component-wiki-navbar-container-padding-block);
+  padding-block: var(--kobber-component-docs-navbar-container-padding-block);
   white-space: nowrap;
-  background-color: var(--kobber-semantics-navigation-color-brightest);
+  background-color: var(--kobber-regional-navigation-color-brightest);
 }
 
 .top-nav-large-screen {

--- a/apps/docs/components/practice-illustration.tsx
+++ b/apps/docs/components/practice-illustration.tsx
@@ -21,7 +21,7 @@ export function PracticeIllustration({
           <div className="flex flex-col justify-between gap-24">
             <div className="grid grid-cols-[fit-content(50px)_1fr] gap-8">
               <X className="size-5 rounded-full bg-red-600 p-0.5 text-[#FDF9F9]" />
-              <span className="text-primary-body text-[#481125ff]">{notAcceptedText}</span>
+              <span className="text-[#481125ff]">{notAcceptedText}</span>
             </div>
             <div className="flex w-[314px] max-w-[314px] items-center justify-center gap-16 rounded-2xl border border-[#691837] bg-[#FDF9F9] p-12">
               {notAcceptedComponent}
@@ -30,7 +30,7 @@ export function PracticeIllustration({
           <div className="flex flex-col justify-between gap-24">
             <div className="grid grid-cols-[fit-content(50px)_1fr] gap-8">
               <Check className="size-5 rounded-full bg-green-600 p-0.5 text-[#FDF9F9]" />
-              <span className="text-primary-body text-[#481125ff]">{acceptedText}</span>
+              <span className="text-[#481125ff]">{acceptedText}</span>
             </div>
             <div className="flex w-[314px] max-w-[314px] items-center justify-center gap-16 rounded-2xl border border-[#691837] bg-[#FDF9F9] p-12">
               {acceptedComponent}

--- a/apps/docs/styles/globals.css
+++ b/apps/docs/styles/globals.css
@@ -78,11 +78,11 @@
   }
 
   body {
-    color: var(--kobber-component-article-body-text-color-base);
-    background-color: var(--kobber-semantics-navigation-color-brightest);
+    color: var(--kobber-component-body-text-color-base);
+    background-color: var(--kobber-regional-navigation-color-brightest);
 
     --top-nav-height: calc(
-      2 * var(--kobber-component-wiki-navbar-container-padding-block) +
+      2 * var(--kobber-component-docs-navbar-container-padding-block) +
         var(--kobber-component-button-container-size-height)
     );
   }

--- a/apps/docs/styles/page-layout.module.css
+++ b/apps/docs/styles/page-layout.module.css
@@ -1,6 +1,6 @@
 .page-spacing {
-  max-width: var(--kobber-template-page-width-max);
-  min-width: var(--kobber-template-page-width-min);
+  max-width: var(--kobber-global-layout-page-width-max);
+  min-width: var(--kobber-global-layout-page-width-min);
   margin-inline: auto;
   padding-inline: var(--kobber-layout-gap-16-32);
   padding-top: var(--kobber-layout-gap-16-44);

--- a/apps/docs/tailwind.config.ts
+++ b/apps/docs/tailwind.config.ts
@@ -3,19 +3,7 @@ import { tokens } from "./lib/theme"
 
 const mode = "default"
 
-const semantics = tokens[mode].semantics
-const typography = tokens[mode].typography
 const component = tokens[mode].component
-
-const textSection = tokens[mode].template["text-wrapper"]
-
-const global = tokens[mode].global.text
-
-const { typography: text } = semantics
-const { primary, secondary } = typography
-const { gap: textSectionGap } = textSection
-
-const { ui } = global
 
 const config = {
   darkMode: ["class"],
@@ -55,12 +43,12 @@ const config = {
       space: {},
       gap: {
         "page/gap/horizontal": "48px", // change this as we wait for a new template component
-        "section/gap/horizontal": `${textSectionGap.horizontal}px`,
-        "section/gap/vertical": `${textSectionGap.horizontal}px`,
+        "section/gap/horizontal": "1rem",
+        "section/gap/vertical": "1rem",
         "content/gap/horizontal": "16px",
-        "text-section/gap/header/horizontal": `${textSectionGap.horizontal}px`,
-        "text-section/gap/header-ingress-body/horizontal": `${textSectionGap.horizontal}px`,
-        "main/gap/vertical": `${textSectionGap.horizontal}px`,
+        "text-section/gap/header/horizontal": "1rem",
+        "text-section/gap/header-ingress-body/horizontal": "1rem",
+        "main/gap/vertical": "1rem",
       },
 
       maxHeight: {},
@@ -72,124 +60,9 @@ const config = {
         lyon: ["var(--font-lyon)"],
         inter: ["var(--font-inter)"],
       },
-      fontWeight: {
-        light: `${text.weight.light}`,
-        book: `${text.weight.book}`,
-        regular: `${text.weight.regular}`,
-        medium: `${text.weight.medium}`,
-        semibold: `${text.weight["semi-bold"]}`,
-      },
-      fontSize: {
-        "text/ui/size/button": [`${ui.size.button}px`, {}],
-        "primary-display-l": [
-          `${primary["display large"].fontSize}px`,
-          {
-            lineHeight: `${primary["display large"].lineHeight}px`,
-            fontWeight: `${primary["display large"].fontWeight}`,
-          },
-        ],
-        "primary-display-m": [
-          `${primary["display medium"].fontSize}px`,
-          {
-            lineHeight: `${primary["display medium"].lineHeight}px`,
-            fontWeight: `${primary["display medium"].fontWeight}`,
-          },
-        ],
-        "text/primary/size/display/small": [
-          `${primary["display small"].fontSize}px`,
-          {
-            lineHeight: `${primary["display small"].lineHeight}px`,
-            fontWeight: `${primary["display small"].fontWeight}`,
-          },
-        ],
-        "primary-heading-m": [
-          `${primary["heading medium"].fontSize}px`,
-          {
-            lineHeight: `${primary["heading medium"].lineHeight}px`,
-            fontWeight: `${primary["heading medium"].fontWeight}`,
-          },
-        ],
-        "primary-heading-s": [
-          `${primary["heading small"].fontSize}px`,
-          {
-            lineHeight: `${primary["heading small"].lineHeight}px`,
-            fontWeight: `${primary["heading small"].fontWeight}`,
-          },
-        ],
-        "primary-title-m": [
-          `${primary["title medium"].fontSize}px`,
-          {
-            lineHeight: `${primary["title medium"].lineHeight}px`,
-            fontWeight: `${primary["title medium"].fontWeight}`,
-          },
-        ],
-        "primary-title-s": [
-          `${primary["title small"].fontSize}px`,
-          {
-            lineHeight: `${primary["title small"].lineHeight}px`,
-            fontWeight: `${primary["title small"].fontWeight}`,
-          },
-        ],
-        "primary-body": [
-          `${primary.body.fontSize}px`,
-          {
-            lineHeight: `${primary.body.lineHeight}px`,
-            fontWeight: `${primary.body.fontWeight}`,
-          },
-        ],
-        "primary-label-m": [
-          `${primary["label medium"].fontSize}px`,
-          {
-            lineHeight: `${primary["label medium"].lineHeight}px`,
-            fontWeight: `${primary["label medium"].fontWeight}`,
-          },
-        ],
-        "primary-label-s": [
-          `${primary["label small"].fontSize}px`,
-          {
-            lineHeight: `${primary["label small"].lineHeight}px`,
-            fontWeight: `${primary["label small"].fontWeight}`,
-          },
-        ],
-        "secondary-display-l": [
-          `${secondary["display large"].fontSize}px`,
-          {
-            lineHeight: `${secondary["display large"].lineHeight}px`,
-            fontWeight: `${secondary["display large"].fontWeight}`,
-          },
-        ],
-        "secondary-display-m": [
-          `${secondary["display medium"].fontSize}px`,
-          {
-            lineHeight: `${secondary["display medium"].lineHeight}px`,
-            fontWeight: `${secondary["display medium"].fontWeight}`,
-          },
-        ],
-        "secondary-display-s": [
-          `${secondary["display small"].fontSize}px`,
-          {
-            lineHeight: `${secondary["display small"].lineHeight}px`,
-            fontWeight: `${secondary["display small"].fontWeight}`,
-          },
-        ],
-        "secondary-heading-m": [
-          `${secondary["heading medium"].fontSize}px`,
-          {
-            lineHeight: `${secondary["heading medium"].lineHeight}px`,
-            fontWeight: `${secondary["heading medium"].fontWeight}`,
-          },
-        ],
-        "secondary-heading-s": [
-          `${secondary["heading small"].fontSize}px`,
-          {
-            lineHeight: `${secondary["heading small"].lineHeight}px`,
-            fontWeight: `${secondary["heading small"].fontWeight}`,
-          },
-        ],
-      },
       borderRadius: {},
       colors: {
-        highlight: component.article.heading.text.color.highlight,
+        highlight: component.heading.text.color.highlight,
         border: "hsl(var(--border))",
         input: "hsl(var(--input))",
         link: component.link.text.color,
@@ -242,7 +115,6 @@ const config = {
       },
     },
   },
-  plugins: [require("tailwindcss-animate")],
 } satisfies Config
 
 export default config

--- a/apps/storybook-web-components/.storybook/kobberTheme.js
+++ b/apps/storybook-web-components/.storybook/kobberTheme.js
@@ -1,5 +1,5 @@
 import { create } from "@storybook/theming";
-import { semantics } from "@gyldendal/kobber-base/themes/default/tokens";
+import { regional } from "@gyldendal/kobber-base/themes/default/tokens";
 
 const background = semantics.navigation.color.darkest;
 
@@ -12,11 +12,11 @@ export default create({
   brandTitle: "Kobber Storybook",
   brandImage: "https://dam-prod.gyldendaldigital.no/tenants/edu/file/D_8MwlmJKANA6W4OIRWa7k/*/logo.svg",
 
-  colorSecondary: semantics.navigation.color.bright,
+  colorSecondary: regional.navigation.color.bright,
 
   appBg: background,
   appContentBg: background,
-  appPreviewBg: semantics.navigation.color.brightest,
+  appPreviewBg: regional.navigation.color.brightest,
 
   barBg: background,
 });

--- a/apps/storybook-web-components/public/global.css
+++ b/apps/storybook-web-components/public/global.css
@@ -5,8 +5,8 @@
 
 .kobber-theme-default,
 .kobber-theme-dark {
-  color: var(--kobber-component-article-body-text-color-base);
-  background-color: var(--kobber-semantics-navigation-color-brightest);
+  color: var(--kobber-component-body-text-color-base);
+  background-color: var(--kobber-regional-navigation-color-brightest);
   font-family:
     PP Mori,
     sans-serif;

--- a/packages/kobber-base/src/styleDictionary/buildThemeTokens.ts
+++ b/packages/kobber-base/src/styleDictionary/buildThemeTokens.ts
@@ -27,6 +27,7 @@ export const buildThemeTokens = async (
 
   try {
     const sd = new StyleDictionary(styleDictionaryConfig);
+    sd.log.verbosity = "verbose";
     await sd.hasInitialized;
     await sd.buildAllPlatforms();
     return { allTokens, styleDictionaryConfig };

--- a/packages/kobber-base/tokens-from-figma/design-tokens.tokens.json
+++ b/packages/kobber-base/tokens-from-figma/design-tokens.tokens.json
@@ -1448,67 +1448,67 @@
       }
     }
   },
-  "semantics": {
+  "regional": {
     "action": {
       "space": {
         "small": {
           "description": "",
           "type": "color",
-          "value": "{semantics.layout.element.space.xsmall}"
+          "value": "{global.layout.element.space.xsmall}"
         },
         "large": {
           "description": "",
           "type": "color",
-          "value": "{semantics.layout.element.space.medium}"
+          "value": "{global.layout.element.space.medium}"
         },
         "xlarge": {
           "description": "",
           "type": "color",
-          "value": "{semantics.layout.element.space.large}"
+          "value": "{global.layout.element.space.large}"
         },
         "xsmall": {
           "description": "",
           "type": "color",
-          "value": "{semantics.layout.element.space.xxsmall}"
+          "value": "{global.layout.element.space.xxsmall}"
         },
         "medium": {
           "description": "",
           "type": "color",
-          "value": "{semantics.layout.element.space.small}"
+          "value": "{global.layout.element.space.small}"
         }
       },
       "size": {
         "xlarge": {
           "description": "",
           "type": "color",
-          "value": "{semantics.layout.element.size.large}"
+          "value": "{global.layout.element.size.large}"
         },
         "large": {
           "description": "",
           "type": "color",
-          "value": "{semantics.layout.element.size.medium}"
+          "value": "{global.layout.element.size.medium}"
         },
         "medium": {
           "description": "",
           "type": "color",
-          "value": "{semantics.layout.element.size.small}"
+          "value": "{global.layout.element.size.small}"
         },
         "small": {
           "description": "",
           "type": "color",
-          "value": "{semantics.layout.element.size.xsmall}"
+          "value": "{global.layout.element.size.xsmall}"
         }
       },
       "stroke": {
         "regular": {
           "description": "",
           "type": "color",
-          "value": "{semantics.layout.element.stroke.regular}"
+          "value": "{global.layout.element.stroke.regular}"
         },
         "thick": {
           "description": "",
           "type": "color",
-          "value": "{semantics.layout.element.stroke.thick}"
+          "value": "{global.layout.element.stroke.thick}"
         }
       },
       "color": {
@@ -1517,22 +1517,22 @@
             "dark": {
               "description": "",
               "type": "color",
-              "value": "{semantics.color.identity.base.aubergine-750}"
+              "value": "{global.color.identity.base.aubergine-750}"
             },
             "bright": {
               "description": "",
               "type": "color",
-              "value": "{semantics.color.identity.base.aubergine-50}"
+              "value": "{global.color.identity.base.aubergine-50}"
             },
             "darkest": {
               "description": "",
               "type": "color",
-              "value": "{semantics.color.identity.base.aubergine-1000}"
+              "value": "{global.color.identity.base.aubergine-1000}"
             },
             "brightest": {
               "description": "",
               "type": "color",
-              "value": "{semantics.color.identity.base.aubergine-25}"
+              "value": "{global.color.identity.base.aubergine-25}"
             }
           },
           "transparent": {
@@ -1558,22 +1558,22 @@
             "bright": {
               "description": "",
               "type": "color",
-              "value": "{semantics.color.identity.neutral.concrete-50}"
+              "value": "{global.color.identity.neutral.concrete-50}"
             },
             "darkest": {
               "description": "",
               "type": "color",
-              "value": "{semantics.color.identity.neutral.concrete-900}"
+              "value": "{global.color.identity.neutral.concrete-900}"
             },
             "dark": {
               "description": "",
               "type": "color",
-              "value": "{semantics.color.identity.neutral.concrete-525}"
+              "value": "{global.color.identity.neutral.concrete-525}"
             },
             "brightest": {
               "description": "",
               "type": "color",
-              "value": "{semantics.color.identity.neutral.concrete-25}"
+              "value": "{global.color.identity.neutral.concrete-25}"
             }
           },
           "transparent": {
@@ -1594,12 +1594,12 @@
             "darkest": {
               "description": "",
               "type": "color",
-              "value": "{semantics.color.identity.brand.carmine-525}"
+              "value": "{global.color.identity.brand.carmine-525}"
             },
             "brightest": {
               "description": "",
               "type": "color",
-              "value": "{semantics.color.identity.extended.carmine-25}"
+              "value": "{global.color.identity.extended.carmine-25}"
             }
           },
           "transparent": {
@@ -1615,17 +1615,17 @@
             "midtone": {
               "description": "",
               "type": "color",
-              "value": "{semantics.color.identity.rettsdata.rettsdata-60}"
+              "value": "{global.color.identity.rettsdata.rettsdata-60}"
             },
             "brightest": {
               "description": "",
               "type": "color",
-              "value": "{semantics.color.identity.rettsdata.rettsdata-20}"
+              "value": "{global.color.identity.rettsdata.rettsdata-20}"
             },
             "darkest": {
               "description": "",
               "type": "color",
-              "value": "{semantics.color.identity.rettsdata.rettsdata-90}"
+              "value": "{global.color.identity.rettsdata.rettsdata-90}"
             }
           },
           "transparent": {
@@ -1646,17 +1646,17 @@
             "brightest": {
               "description": "",
               "type": "color",
-              "value": "{semantics.color.ui.success.success-75}"
+              "value": "{global.color.ui.success.success-75}"
             },
             "midtone": {
               "description": "",
               "type": "color",
-              "value": "{semantics.color.ui.success.success-125}"
+              "value": "{global.color.ui.success.success-125}"
             },
             "darkest": {
               "description": "",
               "type": "color",
-              "value": "{semantics.color.ui.success.success-700}"
+              "value": "{global.color.ui.success.success-700}"
             }
           },
           "transparent": {
@@ -1677,12 +1677,12 @@
             "brightest": {
               "description": "",
               "type": "color",
-              "value": "{semantics.color.ui.informative.informative-25}"
+              "value": "{global.color.ui.informative.informative-25}"
             },
             "darkest": {
               "description": "",
               "type": "color",
-              "value": "{semantics.color.ui.informative.informative-700}"
+              "value": "{global.color.ui.informative.informative-700}"
             }
           },
           "transparent": {
@@ -1703,12 +1703,12 @@
             "brightest": {
               "description": "",
               "type": "color",
-              "value": "{semantics.color.ui.warning.warning-75}"
+              "value": "{global.color.ui.warning.warning-75}"
             },
             "darkest": {
               "description": "",
               "type": "color",
-              "value": "{semantics.color.ui.warning.warning-700}"
+              "value": "{global.color.ui.warning.warning-700}"
             }
           },
           "transparent": {
@@ -1729,12 +1729,12 @@
             "darkest": {
               "description": "",
               "type": "color",
-              "value": "{semantics.color.theme.nostalgia.nostalgia-850}"
+              "value": "{global.color.theme.nostalgia.nostalgia-850}"
             },
             "brightest": {
               "description": "",
               "type": "color",
-              "value": "{semantics.color.theme.nostalgia.nostalgia-25}"
+              "value": "{global.color.theme.nostalgia.nostalgia-25}"
             }
           },
           "transparent": {
@@ -1755,12 +1755,12 @@
             "darkest": {
               "description": "",
               "type": "color",
-              "value": "{semantics.color.theme.vacation.vacation-150}"
+              "value": "{global.color.theme.vacation.vacation-150}"
             },
             "brightest": {
               "description": "",
               "type": "color",
-              "value": "{semantics.color.theme.vacation.vacation-25}"
+              "value": "{global.color.theme.vacation.vacation-25}"
             }
           },
           "transparent": {
@@ -1781,12 +1781,12 @@
             "darkest": {
               "description": "",
               "type": "color",
-              "value": "{semantics.color.theme.nature.nature-750}"
+              "value": "{global.color.theme.nature.nature-750}"
             },
             "brightest": {
               "description": "",
               "type": "color",
-              "value": "{semantics.color.theme.nature.nature-25}"
+              "value": "{global.color.theme.nature.nature-25}"
             }
           },
           "transparent": {
@@ -1807,12 +1807,12 @@
             "darkest": {
               "description": "",
               "type": "color",
-              "value": "{semantics.color.theme.romance.romance-750}"
+              "value": "{global.color.theme.romance.romance-750}"
             },
             "brightest": {
               "description": "",
               "type": "color",
-              "value": "{semantics.color.theme.romance.romance-50}"
+              "value": "{global.color.theme.romance.romance-50}"
             }
           },
           "transparent": {
@@ -1833,12 +1833,12 @@
             "darkest": {
               "description": "",
               "type": "color",
-              "value": "{semantics.color.theme.fantasy.fantasy-850}"
+              "value": "{global.color.theme.fantasy.fantasy-850}"
             },
             "brightest": {
               "description": "",
               "type": "color",
-              "value": "{semantics.color.theme.fantasy.fantasy-250}"
+              "value": "{global.color.theme.fantasy.fantasy-250}"
             }
           },
           "transparent": {
@@ -1859,12 +1859,12 @@
             "darkest": {
               "description": "",
               "type": "color",
-              "value": "{semantics.color.theme.thriller.thriller-900}"
+              "value": "{global.color.theme.thriller.thriller-900}"
             },
             "brightest": {
               "description": "",
               "type": "color",
-              "value": "{semantics.color.theme.thriller.thriller-250}"
+              "value": "{global.color.theme.thriller.thriller-250}"
             }
           },
           "transparent": {
@@ -1884,555 +1884,35 @@
           "midtone": {
             "description": "",
             "type": "color",
-            "value": "{semantics.color.identity.extended.wine-600}"
+            "value": "{global.color.identity.extended.wine-600}"
           }
         }
       },
       "radius": {
-        "xxsmall": {
+        "small": {
           "description": "",
           "type": "color",
-          "value": "{semantics.layout.element.radius.xsmall}"
+          "value": "{global.layout.element.radius.xsmall}"
         },
-        "xsmall": {
+        "medium": {
           "description": "",
           "type": "color",
-          "value": "{semantics.layout.element.radius.small}"
+          "value": "{global.layout.element.radius.small}"
         }
       },
       "visual": {
         "icon": {
-          "regular": {
-            "description": "",
-            "type": "color",
-            "value": "{semantics.visual.icon.size.medium}"
-          },
-          "small": {
-            "description": "",
-            "type": "color",
-            "value": "{semantics.visual.icon.size.small}"
-          }
-        }
-      }
-    },
-    "layout": {
-      "page": {
-        "space": {
-          "medium": {
-            "description": "",
-            "type": "dimension",
-            "value": "{primitives.size.40}"
-          },
-          "small": {
-            "description": "",
-            "type": "dimension",
-            "value": "{primitives.size.32}"
-          },
-          "xsmall": {
-            "description": "",
-            "type": "dimension",
-            "value": "{primitives.size.24}"
-          },
-          "xlarge": {
-            "description": "",
-            "type": "dimension",
-            "value": "{primitives.size.64}"
-          },
-          "large": {
-            "description": "",
-            "type": "dimension",
-            "value": "{primitives.size.48}"
-          },
-          "xxsmall": {
-            "description": "",
-            "type": "dimension",
-            "value": "{primitives.size.16}"
-          },
-          "xxlarge": {
-            "description": "",
-            "type": "dimension",
-            "value": "{primitives.size.128}"
-          }
-        },
-        "width": {
-          "min": {
-            "description": "",
-            "type": "dimension",
-            "value": "{primitives.size.320}"
-          },
-          "max": {
-            "description": "",
-            "type": "dimension",
-            "value": "{primitives.size.1600}"
-          }
-        },
-        "breakpoint": {
-          "narrow": {
-            "description": "",
-            "type": "dimension",
-            "value": "{primitives.size.640}"
-          },
-          "wide": {
-            "description": "",
-            "type": "dimension",
-            "value": "{primitives.size.1280}"
-          }
-        }
-      },
-      "element": {
-        "space": {
-          "xsmall": {
-            "description": "",
-            "type": "dimension",
-            "value": "{primitives.size.8}"
-          },
-          "medium": {
-            "description": "",
-            "type": "dimension",
-            "value": "{primitives.size.16}"
-          },
-          "large": {
-            "description": "",
-            "type": "dimension",
-            "value": "{primitives.size.24}"
-          },
-          "xlarge": {
-            "description": "",
-            "type": "dimension",
-            "value": "{primitives.size.32}"
-          },
-          "small": {
-            "description": "",
-            "type": "dimension",
-            "value": "{primitives.size.12}"
-          },
-          "xxsmall": {
-            "description": "",
-            "type": "dimension",
-            "value": "{primitives.size.4}"
-          },
-          "tiny": {
-            "description": "",
-            "type": "dimension",
-            "value": "{primitives.size.2}"
-          },
-          "xxlarge": {
-            "description": "",
-            "type": "dimension",
-            "value": "{primitives.size.40}"
-          },
-          "xxxlarge": {
-            "description": "",
-            "type": "dimension",
-            "value": "{primitives.size.64}"
-          }
-        },
-        "radius": {
-          "xsmall": {
-            "description": "",
-            "type": "dimension",
-            "value": "{primitives.size.8}"
-          },
-          "small": {
-            "description": "",
-            "type": "dimension",
-            "value": "{primitives.size.10}"
-          },
-          "medium": {
-            "description": "",
-            "type": "dimension",
-            "value": "{primitives.size.16}"
-          },
-          "large": {
-            "description": "",
-            "type": "dimension",
-            "value": "{primitives.size.24}"
-          },
-          "xlarge": {
-            "description": "",
-            "type": "dimension",
-            "value": "{primitives.size.32}"
-          },
-          "pill": {
-            "description": "",
-            "type": "dimension",
-            "value": "{primitives.size.1000}"
-          }
-        },
-        "stroke": {
-          "regular": {
-            "description": "",
-            "type": "dimension",
-            "value": "{primitives.size.1}"
-          },
-          "thick": {
-            "description": "",
-            "type": "dimension",
-            "value": "{primitives.size.2}"
-          },
-          "fat": {
-            "description": "",
-            "type": "dimension",
-            "value": "{primitives.size.4}"
-          }
-        },
-        "size": {
-          "medium": {
-            "description": "",
-            "type": "dimension",
-            "value": "{primitives.size.32}"
-          },
-          "large": {
-            "description": "",
-            "type": "dimension",
-            "value": "{primitives.size.40}"
-          },
-          "small": {
-            "description": "",
-            "type": "dimension",
-            "value": "{primitives.size.24}"
-          },
-          "xlarge": {
-            "description": "",
-            "type": "dimension",
-            "value": "{primitives.size.48}"
-          },
-          "xsmall": {
-            "description": "",
-            "type": "dimension",
-            "value": "{primitives.size.16}"
-          }
-        }
-      }
-    },
-    "visual": {
-      "icon": {
-        "size": {
-          "medium": {
-            "description": "",
-            "type": "dimension",
-            "value": "{primitives.size.20}"
-          },
-          "small": {
-            "description": "",
-            "type": "dimension",
-            "value": "{primitives.size.16}"
-          }
-        }
-      }
-    },
-    "color": {
-      "ui": {
-        "success": {
-          "success-75": {
-            "description": "",
-            "type": "color",
-            "value": "{primitives.color.green.75}"
-          },
-          "success-125": {
-            "description": "",
-            "type": "color",
-            "value": "{primitives.color.green.125}"
-          },
-          "success-175": {
-            "description": "",
-            "type": "color",
-            "value": "{primitives.color.green.175}"
-          },
-          "success-450": {
-            "description": "",
-            "type": "color",
-            "value": "{primitives.color.green.450}"
-          },
-          "success-700": {
-            "description": "",
-            "type": "color",
-            "value": "{primitives.color.green.700}"
-          }
-        },
-        "warning": {
-          "warning-125": {
-            "description": "",
-            "type": "color",
-            "value": "{primitives.color.orange.125}"
-          },
-          "warning-175": {
-            "description": "",
-            "type": "color",
-            "value": "{primitives.color.orange.175}"
-          },
-          "warning-450": {
-            "description": "",
-            "type": "color",
-            "value": "{primitives.color.orange.450}"
-          },
-          "warning-700": {
-            "description": "",
-            "type": "color",
-            "value": "{primitives.color.orange.700}"
-          },
-          "warning-75": {
-            "description": "",
-            "type": "color",
-            "value": "{primitives.color.orange.75}"
-          }
-        },
-        "informative": {
-          "informative-25": {
-            "description": "",
-            "type": "color",
-            "value": "{primitives.color.purple.25}"
-          },
-          "informative-125": {
-            "description": "",
-            "type": "color",
-            "value": "{primitives.color.purple.125}"
-          },
-          "informative-175": {
-            "description": "",
-            "type": "color",
-            "value": "{primitives.color.purple.175}"
-          },
-          "informative-450": {
-            "description": "",
-            "type": "color",
-            "value": "{primitives.color.purple.450}"
-          },
-          "informative-700": {
-            "description": "",
-            "type": "color",
-            "value": "{primitives.color.purple.700}"
-          }
-        }
-      },
-      "identity": {
-        "extended": {
-          "carmine-25": {
-            "description": "",
-            "type": "color",
-            "value": "{primitives.color.carmine.25}"
-          },
-          "aubergine-425": {
-            "description": "",
-            "type": "color",
-            "value": "{primitives.color.aubergine.425}"
-          },
-          "aubergine-525": {
-            "description": "",
-            "type": "color",
-            "value": "{primitives.color.aubergine.525}"
-          },
-          "wine-150": {
-            "description": "",
-            "type": "color",
-            "value": "{primitives.color.wine.150}"
-          },
-          "wine-600": {
-            "description": "",
-            "type": "color",
-            "value": "{primitives.color.wine.600}"
-          },
-          "wine-50": {
-            "description": "",
-            "type": "color",
-            "value": "{primitives.color.wine.50}"
-          },
-          "wine-525": {
-            "description": "",
-            "type": "color",
-            "value": "{primitives.color.wine.525}"
-          }
-        },
-        "base": {
-          "aubergine-25": {
-            "description": "",
-            "type": "color",
-            "value": "{primitives.color.aubergine.25}"
-          },
-          "aubergine-50": {
-            "description": "",
-            "type": "color",
-            "value": "{primitives.color.aubergine.50}"
-          },
-          "aubergine-750": {
-            "description": "",
-            "type": "color",
-            "value": "{primitives.color.aubergine.750}"
-          },
-          "aubergine-850": {
-            "description": "",
-            "type": "color",
-            "value": "{primitives.color.aubergine.850}"
-          },
-          "aubergine-900": {
-            "description": "",
-            "type": "color",
-            "value": "{primitives.color.aubergine.900}"
-          },
-          "aubergine-1000": {
-            "description": "",
-            "type": "color",
-            "value": "{primitives.color.aubergine.1000}"
-          },
-          "aubergine-150": {
-            "description": "",
-            "type": "color",
-            "value": "{primitives.color.aubergine.150}"
-          },
-          "aubergine-675": {
-            "description": "",
-            "type": "color",
-            "value": "{primitives.color.aubergine.675}"
-          }
-        },
-        "neutral": {
-          "concrete-25": {
-            "description": "",
-            "type": "color",
-            "value": "{primitives.color.concrete.25}"
-          },
-          "concrete-50": {
-            "description": "",
-            "type": "color",
-            "value": "{primitives.color.concrete.50}"
-          },
-          "concrete-525": {
-            "description": "",
-            "type": "color",
-            "value": "{primitives.color.concrete.525}"
-          },
-          "concrete-900": {
-            "description": "",
-            "type": "color",
-            "value": "{primitives.color.concrete.900}"
-          }
-        },
-        "brand": {
-          "carmine-525": {
-            "description": "",
-            "type": "color",
-            "value": "{primitives.color.carmine.525}"
-          }
-        },
-        "rettsdata": {
-          "rettsdata-20": {
-            "description": "",
-            "type": "color",
-            "value": "{primitives.color.lawblue.20}"
-          },
-          "rettsdata-60": {
-            "description": "",
-            "type": "color",
-            "value": "{primitives.color.lawblue.60}"
-          },
-          "rettsdata-90": {
-            "description": "",
-            "type": "color",
-            "value": "{primitives.color.lawblue.90}"
-          }
-        }
-      },
-      "theme": {
-        "nostalgia": {
-          "nostalgia-25": {
-            "description": "",
-            "type": "color",
-            "value": "{primitives.color.nostalgia.25}"
-          },
-          "nostalgia-600": {
-            "description": "",
-            "type": "color",
-            "value": "{primitives.color.nostalgia.600}"
-          },
-          "nostalgia-850": {
-            "description": "",
-            "type": "color",
-            "value": "{primitives.color.nostalgia.850}"
-          }
-        },
-        "nature": {
-          "nature-25": {
-            "description": "",
-            "type": "color",
-            "value": "{primitives.color.nature.25}"
-          },
-          "nature-525": {
-            "description": "",
-            "type": "color",
-            "value": "{primitives.color.nature.525}"
-          },
-          "nature-750": {
-            "description": "",
-            "type": "color",
-            "value": "{primitives.color.nature.750}"
-          }
-        },
-        "romance": {
-          "romance-50": {
-            "description": "",
-            "type": "color",
-            "value": "{primitives.color.romance.50}"
-          },
-          "romance-675": {
-            "description": "",
-            "type": "color",
-            "value": "{primitives.color.romance.675}"
-          },
-          "romance-750": {
-            "description": "",
-            "type": "color",
-            "value": "{primitives.color.romance.750}"
-          }
-        },
-        "vacation": {
-          "vacation-25": {
-            "description": "",
-            "type": "color",
-            "value": "{primitives.color.vacation.25}"
-          },
-          "vacation-600": {
-            "description": "",
-            "type": "color",
-            "value": "{primitives.color.vacation.600}"
-          },
-          "vacation-150": {
-            "description": "",
-            "type": "color",
-            "value": "{primitives.color.vacation.150}"
-          }
-        },
-        "fantasy": {
-          "fantasy-250": {
-            "description": "",
-            "type": "color",
-            "value": "{primitives.color.fantasy.250}"
-          },
-          "fantasy-750": {
-            "description": "",
-            "type": "color",
-            "value": "{primitives.color.fantasy.750}"
-          },
-          "fantasy-850": {
-            "description": "",
-            "type": "color",
-            "value": "{primitives.color.fantasy.850}"
-          }
-        },
-        "thriller": {
-          "thriller-250": {
-            "description": "",
-            "type": "color",
-            "value": "{primitives.color.thriller.250}"
-          },
-          "thriller-750": {
-            "description": "",
-            "type": "color",
-            "value": "{primitives.color.thriller.850}"
-          },
-          "thriller-900": {
-            "description": "",
-            "type": "color",
-            "value": "{primitives.color.thriller.900}"
+          "size": {
+            "regular": {
+              "description": "",
+              "type": "color",
+              "value": "{global.visual.icon.size.regular}"
+            },
+            "small": {
+              "description": "",
+              "type": "color",
+              "value": "{global.visual.icon.size.regular}"
+            }
           }
         }
       }
@@ -2442,34 +1922,39 @@
         "medium": {
           "description": "",
           "type": "color",
-          "value": "{semantics.layout.element.space.small}"
+          "value": "{global.layout.element.space.small}"
         },
         "large": {
           "description": "",
           "type": "color",
-          "value": "{semantics.layout.element.space.medium}"
+          "value": "{global.layout.element.space.medium}"
         },
         "small": {
           "description": "",
           "type": "color",
-          "value": "{semantics.layout.element.space.xsmall}"
+          "value": "{global.layout.element.space.xsmall}"
         },
         "xsmall": {
           "description": "",
           "type": "color",
-          "value": "{semantics.layout.element.space.xxsmall}"
+          "value": "{global.layout.element.space.xxsmall}"
         }
       },
       "stroke": {
         "regular": {
           "description": "",
           "type": "color",
-          "value": "{semantics.layout.element.stroke.regular}"
+          "value": "{global.layout.element.stroke.regular}"
         },
         "thick": {
           "description": "",
           "type": "color",
-          "value": "{semantics.layout.element.stroke.thick}"
+          "value": "{global.layout.element.stroke.thick}"
+        },
+        "fat": {
+          "description": "",
+          "type": "color",
+          "value": "{global.layout.element.stroke.fat}"
         }
       },
       "color": {
@@ -2477,123 +1962,3853 @@
           "darkest": {
             "description": "",
             "type": "color",
-            "value": "{semantics.color.ui.success.success-700}"
+            "value": "{global.color.ui.success.success-700}"
           },
           "brightest": {
             "description": "",
             "type": "color",
-            "value": "{semantics.color.ui.success.success-75}"
+            "value": "{global.color.ui.success.success-75}"
           },
           "midtone": {
             "description": "",
             "type": "color",
-            "value": "{semantics.color.ui.success.success-175}"
+            "value": "{global.color.ui.success.success-175}"
           }
         },
         "base": {
           "brightest": {
             "description": "",
             "type": "color",
-            "value": "{semantics.color.identity.base.aubergine-50}"
+            "value": "{global.color.identity.base.aubergine-50}"
           },
           "bright": {
             "description": "",
             "type": "color",
-            "value": "{semantics.color.identity.base.aubergine-150}"
+            "value": "{global.color.identity.base.aubergine-150}"
           },
           "brighter": {
             "description": "",
             "type": "color",
-            "value": "{semantics.color.identity.extended.wine-150}"
+            "value": "{global.color.identity.extended.wine-150}"
           },
           "dark": {
             "description": "",
             "type": "color",
-            "value": "{semantics.color.identity.base.aubergine-675}"
+            "value": "{global.color.identity.base.aubergine-675}"
           },
           "darker": {
             "description": "",
             "type": "color",
-            "value": "{semantics.color.identity.base.aubergine-850}"
+            "value": "{global.color.identity.base.aubergine-850}"
           },
           "darkest": {
             "description": "",
             "type": "color",
-            "value": "{semantics.color.identity.base.aubergine-900}"
+            "value": "{global.color.identity.base.aubergine-900}"
           },
           "midtone": {
             "description": "",
             "type": "color",
-            "value": "{semantics.color.identity.extended.wine-525}"
+            "value": "{global.color.identity.extended.wine-525}"
           }
         }
       },
       "radius": {
-        "description": "",
-        "type": "color",
-        "value": "{semantics.layout.element.radius.xsmall}"
+        "small": {
+          "description": "",
+          "type": "color",
+          "value": "{global.layout.element.radius.xsmall}"
+        },
+        "pill": {
+          "description": "",
+          "type": "color",
+          "value": "{global.layout.element.radius.pill}"
+        },
+        "large": {
+          "description": "",
+          "type": "color",
+          "value": "{global.layout.element.radius.large}"
+        }
       },
       "size": {
         "medium": {
           "description": "",
           "type": "color",
-          "value": "{semantics.layout.element.size.medium}"
+          "value": "{global.layout.element.size.medium}"
         },
         "large": {
           "description": "",
           "type": "color",
-          "value": "{semantics.layout.element.size.large}"
+          "value": "{global.layout.element.size.large}"
         },
         "small": {
           "description": "",
           "type": "color",
-          "value": "{semantics.layout.element.size.small}"
+          "value": "{global.layout.element.size.small}"
         }
       }
     },
-    "typography": {
-      "weight": {
-        "regular": {
+    "structural": {
+      "radius": {
+        "description": "",
+        "type": "color",
+        "value": "{global.layout.element.radius.pill}"
+      },
+      "stroke": {
+        "description": "",
+        "type": "color",
+        "value": "{global.layout.element.stroke.regular}"
+      },
+      "space": {
+        "description": "",
+        "type": "color",
+        "value": "{global.layout.element.space.tiny}"
+      },
+      "color": {
+        "brightest": {
           "description": "",
-          "type": "dimension",
-          "value": "{primitives.font.weight.400}"
+          "type": "color",
+          "value": "{global.color.identity.extended.wine-150}"
         },
-        "book": {
+        "darkest": {
           "description": "",
-          "type": "dimension",
-          "value": "{primitives.font.weight.300}"
+          "type": "color",
+          "value": "{primitives.color.wine.750}"
+        }
+      }
+    },
+    "data-display": {
+      "color": {
+        "brightest": {
+          "description": "",
+          "type": "color",
+          "value": "{global.color.identity.base.aubergine-25}"
         },
-        "light": {
+        "midtone": {
           "description": "",
-          "type": "dimension",
-          "value": "{primitives.font.weight.200}"
+          "type": "color",
+          "value": "{global.color.identity.base.aubergine-50}"
+        },
+        "bright": {
+          "description": "",
+          "type": "color",
+          "value": "{global.color.identity.extended.wine-50}"
+        },
+        "darker": {
+          "description": "",
+          "type": "color",
+          "value": "{global.color.identity.base.aubergine-850}"
+        },
+        "darkest": {
+          "description": "",
+          "type": "color",
+          "value": "{global.color.identity.base.aubergine-900}"
+        },
+        "dark": {
+          "description": "",
+          "type": "color",
+          "value": "{global.color.identity.extended.wine-150}"
+        },
+        "brand": {
+          "description": "",
+          "type": "color",
+          "value": "{global.color.identity.brand.carmine-525}"
+        }
+      },
+      "stroke": {
+        "description": "",
+        "type": "color",
+        "value": "{global.layout.element.stroke.regular}"
+      },
+      "radius": {
+        "description": "",
+        "type": "color",
+        "value": "{global.layout.element.radius.xsmall}"
+      },
+      "size": {
+        "description": "",
+        "type": "color",
+        "value": "{global.layout.element.size.xlarge}"
+      },
+      "space": {
+        "small": {
+          "description": "",
+          "type": "color",
+          "value": "{global.layout.element.space.xsmall}"
         },
         "medium": {
           "description": "",
-          "type": "dimension",
-          "value": "{primitives.font.weight.500}"
+          "type": "color",
+          "value": "{global.layout.element.space.medium}"
         },
-        "semi-bold": {
+        "xlarge": {
           "description": "",
-          "type": "dimension",
-          "value": "{primitives.font.weight.600}"
+          "type": "color",
+          "value": "{global.layout.element.space.xxlarge}"
+        },
+        "tiny": {
+          "description": "",
+          "type": "color",
+          "value": "{global.layout.element.space.tiny}"
+        }
+      }
+    },
+    "navigation": {
+      "space": {
+        "small": {
+          "description": "",
+          "type": "color",
+          "value": "{global.layout.element.space.xsmall}"
+        },
+        "xxlarge": {
+          "description": "",
+          "type": "color",
+          "value": "{global.layout.element.space.xxxlarge}"
+        },
+        "medium": {
+          "description": "",
+          "type": "color",
+          "value": "{global.layout.element.space.medium}"
+        },
+        "large": {
+          "description": "",
+          "type": "color",
+          "value": "{global.layout.element.space.large}"
+        },
+        "xlarge": {
+          "description": "",
+          "type": "color",
+          "value": "{global.layout.element.space.xxlarge}"
         }
       },
+      "color": {
+        "darkest": {
+          "description": "",
+          "type": "color",
+          "value": "{global.color.identity.base.aubergine-1000}"
+        },
+        "dark": {
+          "description": "",
+          "type": "color",
+          "value": "{global.color.identity.base.aubergine-850}"
+        },
+        "brightest": {
+          "description": "",
+          "type": "color",
+          "value": "{global.color.identity.base.aubergine-25}"
+        },
+        "bright": {
+          "description": "",
+          "type": "color",
+          "value": "{global.color.identity.extended.aubergine-425}"
+        },
+        "midtone": {
+          "description": "",
+          "type": "color",
+          "value": "{global.color.identity.extended.aubergine-525}"
+        }
+      },
+      "stroke": {
+        "description": "",
+        "type": "color",
+        "value": "{global.layout.element.stroke.regular}"
+      },
+      "visual": {
+        "icon": {
+          "size": {
+            "description": "",
+            "type": "color",
+            "value": "{global.visual.icon.size.small}"
+          }
+        }
+      }
+    },
+    "feedback": {
+      "space": {
+        "small": {
+          "description": "",
+          "type": "color",
+          "value": "{global.layout.element.space.xsmall}"
+        },
+        "medium": {
+          "description": "",
+          "type": "color",
+          "value": "{global.layout.element.space.small}"
+        },
+        "large": {
+          "description": "",
+          "type": "color",
+          "value": "{global.layout.element.space.medium}"
+        },
+        "xsmall": {
+          "description": "",
+          "type": "color",
+          "value": "{global.layout.element.space.xxsmall}"
+        },
+        "xlarge": {
+          "description": "",
+          "type": "color",
+          "value": "{global.layout.element.space.large}"
+        }
+      },
+      "radius": {
+        "small": {
+          "description": "",
+          "type": "color",
+          "value": "{global.layout.element.radius.xsmall}"
+        },
+        "medium": {
+          "description": "",
+          "type": "color",
+          "value": "{global.layout.element.radius.small}"
+        }
+      },
+      "color": {
+        "success": {
+          "darkest": {
+            "description": "",
+            "type": "color",
+            "value": "{global.color.ui.success.success-700}"
+          },
+          "brightest": {
+            "description": "",
+            "type": "color",
+            "value": "{global.color.ui.success.success-75}"
+          }
+        },
+        "info": {
+          "brightest": {
+            "description": "",
+            "type": "color",
+            "value": "{global.color.ui.informative.informative-25}"
+          },
+          "darkest": {
+            "description": "",
+            "type": "color",
+            "value": "{global.color.ui.informative.informative-700}"
+          }
+        },
+        "warning": {
+          "brightest": {
+            "description": "",
+            "type": "color",
+            "value": "{global.color.ui.warning.warning-75}"
+          },
+          "darkest": {
+            "description": "",
+            "type": "color",
+            "value": "{global.color.ui.warning.warning-700}"
+          }
+        }
+      },
+      "visual": {
+        "icon": {
+          "size": {
+            "regular": {
+              "description": "",
+              "type": "color",
+              "value": "{global.visual.icon.size.regular}"
+            },
+            "small": {
+              "description": "",
+              "type": "color",
+              "value": "{global.visual.icon.size.small}"
+            }
+          }
+        }
+      }
+    }
+  },
+  "component": {
+    "button": {
+      "background": {
+        "color": {
+          "carmine": {
+            "main": {
+              "primary": {
+                "fallback": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.carmine.opaque.darkest}"
+                },
+                "hover": {
+                  "description": "primitive.carmine.1000 med 10% opacity.",
+                  "type": "color",
+                  "value": "{regional.action.color.carmine.transparent.dark}"
+                }
+              }
+            },
+            "supplemental": {
+              "primary": {
+                "fallback": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.carmine.opaque.brightest}"
+                },
+                "hover": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.aubergine.transparent.midtone}"
+                }
+              }
+            }
+          },
+          "aubergine": {
+            "main": {
+              "primary": {
+                "fallback": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.aubergine.opaque.bright}"
+                },
+                "hover": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.aubergine.transparent.darkest}"
+                }
+              }
+            },
+            "supplemental": {
+              "primary": {
+                "fallback": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.aubergine.opaque.darkest}"
+                },
+                "hover": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.aubergine.transparent.brightest}"
+                }
+              }
+            },
+            "supplemental alt": {
+              "primary": {
+                "fallback": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.aubergine.opaque.brightest}"
+                },
+                "hover": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.aubergine.transparent.darkest}"
+                }
+              }
+            }
+          },
+          "neutral": {
+            "main": {
+              "primary": {
+                "fallback": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.neutral.opaque.bright}"
+                },
+                "hover": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.neutral.transparent.darkest}"
+                }
+              }
+            },
+            "supplemental": {
+              "primary": {
+                "fallback": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.neutral.opaque.darkest}"
+                },
+                "hover": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.neutral.transparent.brightest}"
+                }
+              }
+            },
+            "supplemental alt": {
+              "primary": {
+                "fallback": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.neutral.opaque.dark}"
+                },
+                "hover": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.neutral.transparent.darkest}"
+                }
+              }
+            }
+          },
+          "rettsdata": {
+            "main": {
+              "primary": {
+                "fallback": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.rettsdata.opaque.midtone}"
+                },
+                "hover": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.rettsdata.transparent.darkest}"
+                }
+              }
+            },
+            "supplemental": {
+              "primary": {
+                "fallback": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.rettsdata.opaque.brightest}"
+                },
+                "hover": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.rettsdata.transparent.darkest}"
+                }
+              }
+            },
+            "supplemental alt": {
+              "primary": {
+                "fallback": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.rettsdata.opaque.darkest}"
+                },
+                "hover": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.rettsdata.transparent.brightest}"
+                }
+              }
+            }
+          },
+          "success": {
+            "main": {
+              "primary": {
+                "fallback": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.success.opaque.brightest}"
+                },
+                "hover": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.success.transparent.darkest}"
+                }
+              }
+            },
+            "supplemental": {
+              "primary": {
+                "fallback": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.success.opaque.darkest}"
+                },
+                "hover": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.success.transparent.brightest}"
+                }
+              }
+            }
+          },
+          "informative": {
+            "main": {
+              "primary": {
+                "fallback": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.informative.opaque.brightest}"
+                },
+                "hover": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.informative.transparent.darkest}"
+                }
+              }
+            },
+            "supplemental": {
+              "primary": {
+                "fallback": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.informative.opaque.darkest}"
+                },
+                "hover": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.informative.transparent.brightest}"
+                }
+              }
+            }
+          },
+          "warning": {
+            "main": {
+              "primary": {
+                "fallback": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.warning.opaque.brightest}"
+                },
+                "hover": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.warning.transparent.darkest}"
+                }
+              }
+            },
+            "supplemental": {
+              "primary": {
+                "fallback": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.warning.opaque.darkest}"
+                },
+                "hover": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.warning.transparent.brightest}"
+                }
+              }
+            }
+          },
+          "nostalgia": {
+            "main": {
+              "primary": {
+                "fallback": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.nostalgia.opaque.darkest}"
+                },
+                "hover": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.nostalgia.transparent.brightest}"
+                }
+              }
+            },
+            "supplemental": {
+              "primary": {
+                "fallback": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.nostalgia.opaque.brightest}"
+                },
+                "hover": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.nostalgia.transparent.darkest}"
+                }
+              }
+            }
+          },
+          "nature": {
+            "main": {
+              "primary": {
+                "fallback": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.nature.opaque.darkest}"
+                },
+                "hover": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.nature.transparent.brightest}"
+                }
+              }
+            },
+            "supplemental": {
+              "primary": {
+                "fallback": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.nature.opaque.brightest}"
+                },
+                "hover": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.nature.transparent.darkest}"
+                }
+              }
+            }
+          },
+          "romance": {
+            "main": {
+              "primary": {
+                "fallback": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.romance.opaque.darkest}"
+                },
+                "hover": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.romance.transparent.brightest}"
+                }
+              }
+            },
+            "supplemental": {
+              "primary": {
+                "fallback": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.romance.opaque.brightest}"
+                },
+                "hover": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.romance.transparent.darkest}"
+                }
+              }
+            }
+          },
+          "vacation": {
+            "main": {
+              "primary": {
+                "fallback": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.vacation.opaque.darkest}"
+                },
+                "hover": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.vacation.transparent.brightest}"
+                }
+              }
+            },
+            "supplemental": {
+              "primary": {
+                "fallback": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.vacation.opaque.brightest}"
+                },
+                "hover": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.vacation.transparent.darkest}"
+                }
+              }
+            }
+          },
+          "fantasy": {
+            "main": {
+              "primary": {
+                "fallback": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.fantasy.opaque.darkest}"
+                },
+                "hover": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.fantasy.transparent.brightest}"
+                }
+              }
+            },
+            "supplemental": {
+              "primary": {
+                "fallback": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.fantasy.opaque.brightest}"
+                },
+                "hover": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.fantasy.transparent.darkest}"
+                }
+              }
+            }
+          },
+          "thriller": {
+            "main": {
+              "primary": {
+                "fallback": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.thriller.opaque.darkest}"
+                },
+                "hover": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.thriller.transparent.brightest}"
+                }
+              }
+            },
+            "supplemental": {
+              "primary": {
+                "fallback": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.thriller.opaque.brightest}"
+                },
+                "hover": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.thriller.transparent.darkest}"
+                }
+              }
+            }
+          }
+        }
+      },
+      "container": {
+        "size": {
+          "height": {
+            "description": "",
+            "type": "color",
+            "value": "{regional.action.size.xlarge}"
+          }
+        },
+        "border": {
+          "radius": {
+            "description": "",
+            "type": "color",
+            "value": "{regional.action.radius.small}"
+          },
+          "width": {
+            "hover": {
+              "description": "",
+              "type": "color",
+              "value": "{regional.action.stroke.regular}"
+            },
+            "active": {
+              "description": "",
+              "type": "color",
+              "value": "{regional.action.stroke.regular}"
+            }
+          },
+          "color": {
+            "aubergine": {
+              "main": {
+                "secondary": {
+                  "hover": {
+                    "description": "",
+                    "type": "color",
+                    "value": "{regional.action.color.aubergine.opaque.dark}"
+                  },
+                  "active": {
+                    "description": "",
+                    "type": "color",
+                    "value": "{regional.action.color.aubergine.opaque.dark}"
+                  }
+                }
+              },
+              "supplemental": {
+                "secondary": {
+                  "hover": {
+                    "description": "",
+                    "type": "color",
+                    "value": "{regional.action.color.aubergine.opaque.brightest}"
+                  },
+                  "active": {
+                    "description": "",
+                    "type": "color",
+                    "value": "{regional.action.color.aubergine.opaque.brightest}"
+                  }
+                }
+              }
+            },
+            "carmine": {
+              "main": {
+                "secondary": {
+                  "hover": {
+                    "description": "",
+                    "type": "color",
+                    "value": "{regional.action.color.carmine.opaque.darkest}"
+                  },
+                  "active": {
+                    "description": "",
+                    "type": "color",
+                    "value": "{regional.action.color.carmine.opaque.darkest}"
+                  }
+                }
+              },
+              "supplemental": {
+                "secondary": {
+                  "hover": {
+                    "description": "",
+                    "type": "color",
+                    "value": "{regional.action.color.carmine.opaque.brightest}"
+                  },
+                  "active": {
+                    "description": "",
+                    "type": "color",
+                    "value": "{regional.action.color.carmine.opaque.brightest}"
+                  }
+                }
+              }
+            },
+            "rettsdata": {
+              "main": {
+                "secondary": {
+                  "hover": {
+                    "description": "",
+                    "type": "color",
+                    "value": "{regional.action.color.rettsdata.opaque.midtone}"
+                  },
+                  "active": {
+                    "description": "",
+                    "type": "color",
+                    "value": "{regional.action.color.rettsdata.opaque.midtone}"
+                  }
+                }
+              },
+              "supplemental": {
+                "secondary": {
+                  "hover": {
+                    "description": "",
+                    "type": "color",
+                    "value": "{regional.action.color.rettsdata.opaque.brightest}"
+                  },
+                  "active": {
+                    "description": "",
+                    "type": "color",
+                    "value": "{regional.action.color.rettsdata.opaque.brightest}"
+                  }
+                }
+              }
+            },
+            "neutral": {
+              "main": {
+                "secondary": {
+                  "hover": {
+                    "description": "",
+                    "type": "color",
+                    "value": "{regional.action.color.neutral.opaque.darkest}"
+                  },
+                  "active": {
+                    "description": "",
+                    "type": "color",
+                    "value": "{regional.action.color.neutral.opaque.darkest}"
+                  }
+                }
+              },
+              "supplemental": {
+                "secondary": {
+                  "hover": {
+                    "description": "",
+                    "type": "color",
+                    "value": "{regional.action.color.neutral.opaque.brightest}"
+                  },
+                  "active": {
+                    "description": "",
+                    "type": "color",
+                    "value": "{regional.action.color.neutral.opaque.brightest}"
+                  }
+                }
+              }
+            },
+            "nostalgia": {
+              "main": {
+                "secondary": {
+                  "hover": {
+                    "description": "",
+                    "type": "color",
+                    "value": "{regional.action.color.nostalgia.opaque.darkest}"
+                  },
+                  "active": {
+                    "description": "",
+                    "type": "color",
+                    "value": "{regional.action.color.nostalgia.opaque.darkest}"
+                  }
+                }
+              },
+              "supplemental": {
+                "secondary": {
+                  "hover": {
+                    "description": "",
+                    "type": "color",
+                    "value": "{regional.action.color.nostalgia.opaque.brightest}"
+                  },
+                  "active": {
+                    "description": "",
+                    "type": "color",
+                    "value": "{regional.action.color.nostalgia.opaque.brightest}"
+                  }
+                }
+              }
+            },
+            "nature": {
+              "main": {
+                "secondary": {
+                  "hover": {
+                    "description": "",
+                    "type": "color",
+                    "value": "{regional.action.color.nature.opaque.darkest}"
+                  },
+                  "active": {
+                    "description": "",
+                    "type": "color",
+                    "value": "{regional.action.color.nature.opaque.darkest}"
+                  }
+                }
+              },
+              "supplemental": {
+                "secondary": {
+                  "hover": {
+                    "description": "",
+                    "type": "color",
+                    "value": "{regional.action.color.nature.opaque.brightest}"
+                  },
+                  "active": {
+                    "description": "",
+                    "type": "color",
+                    "value": "{regional.action.color.nature.opaque.brightest}"
+                  }
+                }
+              }
+            },
+            "romance": {
+              "main": {
+                "secondary": {
+                  "hover": {
+                    "description": "",
+                    "type": "color",
+                    "value": "{regional.action.color.romance.opaque.darkest}"
+                  },
+                  "active": {
+                    "description": "",
+                    "type": "color",
+                    "value": "{regional.action.color.romance.opaque.darkest}"
+                  }
+                }
+              },
+              "supplemental": {
+                "secondary": {
+                  "hover": {
+                    "description": "",
+                    "type": "color",
+                    "value": "{regional.action.color.romance.opaque.brightest}"
+                  },
+                  "active": {
+                    "description": "",
+                    "type": "color",
+                    "value": "{regional.action.color.romance.opaque.brightest}"
+                  }
+                }
+              }
+            },
+            "vacation": {
+              "main": {
+                "secondary": {
+                  "hover": {
+                    "description": "",
+                    "type": "color",
+                    "value": "{regional.action.color.vacation.opaque.darkest}"
+                  },
+                  "active": {
+                    "description": "",
+                    "type": "color",
+                    "value": "{regional.action.color.vacation.opaque.darkest}"
+                  }
+                }
+              },
+              "supplemental": {
+                "secondary": {
+                  "hover": {
+                    "description": "",
+                    "type": "color",
+                    "value": "{regional.action.color.vacation.opaque.brightest}"
+                  },
+                  "active": {
+                    "description": "",
+                    "type": "color",
+                    "value": "{regional.action.color.vacation.opaque.brightest}"
+                  }
+                }
+              }
+            },
+            "fantasy": {
+              "main": {
+                "secondary": {
+                  "hover": {
+                    "description": "",
+                    "type": "color",
+                    "value": "{regional.action.color.fantasy.opaque.darkest}"
+                  },
+                  "active": {
+                    "description": "",
+                    "type": "color",
+                    "value": "{regional.action.color.fantasy.opaque.darkest}"
+                  }
+                }
+              },
+              "supplemental": {
+                "secondary": {
+                  "hover": {
+                    "description": "",
+                    "type": "color",
+                    "value": "{regional.action.color.fantasy.opaque.brightest}"
+                  },
+                  "active": {
+                    "description": "",
+                    "type": "color",
+                    "value": "{regional.action.color.fantasy.opaque.brightest}"
+                  }
+                }
+              }
+            },
+            "thriller": {
+              "main": {
+                "secondary": {
+                  "hover": {
+                    "description": "",
+                    "type": "color",
+                    "value": "{regional.action.color.thriller.opaque.darkest}"
+                  },
+                  "active": {
+                    "description": "",
+                    "type": "color",
+                    "value": "{regional.action.color.thriller.opaque.darkest}"
+                  }
+                }
+              },
+              "supplemental": {
+                "secondary": {
+                  "fallback": {
+                    "description": "",
+                    "type": "color",
+                    "value": "{regional.action.color.thriller.opaque.brightest}"
+                  },
+                  "active": {
+                    "description": "",
+                    "type": "color",
+                    "value": "{regional.action.color.thriller.opaque.brightest}"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "gap": {
+          "description": "",
+          "type": "color",
+          "value": "{regional.action.space.small}"
+        },
+        "padding": {
+          "block": {
+            "description": "",
+            "type": "color",
+            "value": "{regional.action.space.small}",
+            "icon-only": {
+              "description": "",
+              "type": "color",
+              "value": "{regional.action.space.medium}"
+            }
+          },
+          "inline": {
+            "description": "",
+            "type": "color",
+            "value": "{regional.action.space.large}",
+            "icon-only": {
+              "description": "",
+              "type": "color",
+              "value": "{regional.action.space.medium}"
+            }
+          }
+        }
+      },
+      "text": {
+        "color": {
+          "carmine": {
+            "main": {
+              "primary": {
+                "fallback": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.carmine.opaque.brightest}"
+                }
+              },
+              "secondary": {
+                "fallback": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.carmine.opaque.darkest}"
+                }
+              }
+            },
+            "supplemental": {
+              "primary": {
+                "fallback": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.carmine.opaque.darkest}"
+                }
+              },
+              "secondary": {
+                "fallback": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.carmine.opaque.brightest}"
+                }
+              }
+            }
+          },
+          "aubergine": {
+            "main": {
+              "primary": {
+                "fallback": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.aubergine.opaque.dark}"
+                }
+              },
+              "secondary": {
+                "fallback": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.aubergine.opaque.dark}"
+                }
+              }
+            },
+            "supplemental": {
+              "primary": {
+                "fallback": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.aubergine.opaque.bright}"
+                }
+              },
+              "secondary": {
+                "fallback": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.aubergine.opaque.bright}"
+                }
+              }
+            },
+            "supplemental alt": {
+              "primary": {
+                "fallback": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.aubergine.opaque.darkest}"
+                }
+              }
+            }
+          },
+          "neutral": {
+            "main": {
+              "primary": {
+                "fallback": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.neutral.opaque.darkest}"
+                }
+              },
+              "secondary": {
+                "fallback": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.neutral.opaque.darkest}"
+                }
+              }
+            },
+            "supplemental": {
+              "primary": {
+                "fallback": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.neutral.opaque.bright}"
+                }
+              },
+              "secondary": {
+                "fallback": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.neutral.opaque.bright}"
+                }
+              }
+            },
+            "supplemental alt": {
+              "primary": {
+                "fallback": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.neutral.opaque.brightest}"
+                }
+              }
+            }
+          },
+          "rettsdata": {
+            "main": {
+              "primary": {
+                "fallback": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.rettsdata.opaque.brightest}"
+                }
+              },
+              "secondary": {
+                "fallback": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.rettsdata.opaque.midtone}"
+                }
+              }
+            },
+            "supplemental": {
+              "primary": {
+                "fallback": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.rettsdata.opaque.midtone}"
+                }
+              },
+              "secondary": {
+                "fallback": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.rettsdata.opaque.brightest}"
+                }
+              }
+            },
+            "supplemental alt": {
+              "primary": {
+                "fallback": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.rettsdata.opaque.brightest}"
+                }
+              }
+            }
+          },
+          "success": {
+            "main": {
+              "primary": {
+                "fallback": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.success.opaque.darkest}"
+                }
+              }
+            },
+            "supplemental": {
+              "primary": {
+                "fallback": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.success.opaque.brightest}"
+                }
+              }
+            }
+          },
+          "informative": {
+            "main": {
+              "primary": {
+                "fallback": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.informative.opaque.darkest}"
+                }
+              }
+            },
+            "supplemental": {
+              "primary": {
+                "fallback": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.informative.opaque.brightest}"
+                }
+              }
+            }
+          },
+          "warning": {
+            "main": {
+              "primary": {
+                "fallback": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.warning.opaque.darkest}"
+                }
+              }
+            },
+            "supplemental": {
+              "primary": {
+                "fallback": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.warning.opaque.brightest}"
+                }
+              }
+            }
+          },
+          "nostalgia": {
+            "main": {
+              "primary": {
+                "fallback": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.nostalgia.opaque.brightest}"
+                }
+              },
+              "secondary": {
+                "fallback": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.nostalgia.opaque.darkest}"
+                }
+              }
+            },
+            "supplemental": {
+              "primary": {
+                "fallback": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.nostalgia.opaque.darkest}"
+                }
+              },
+              "secondary": {
+                "fallback": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.nostalgia.opaque.brightest}"
+                }
+              }
+            }
+          },
+          "nature": {
+            "main": {
+              "primary": {
+                "fallback": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.nature.opaque.brightest}"
+                }
+              },
+              "secondary": {
+                "fallback": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.nature.opaque.darkest}"
+                }
+              }
+            },
+            "supplemental": {
+              "primary": {
+                "fallback": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.nature.opaque.darkest}"
+                }
+              },
+              "secondary": {
+                "fallback": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.nature.opaque.brightest}"
+                }
+              }
+            }
+          },
+          "romance": {
+            "main": {
+              "primary": {
+                "fallback": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.romance.opaque.brightest}"
+                }
+              },
+              "secondary": {
+                "fallback": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.romance.opaque.darkest}"
+                }
+              }
+            },
+            "supplemental": {
+              "primary": {
+                "fallback": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.romance.opaque.darkest}"
+                }
+              },
+              "secondary": {
+                "fallback": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.romance.opaque.brightest}"
+                }
+              }
+            }
+          },
+          "vacation": {
+            "main": {
+              "primary": {
+                "fallback": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.vacation.opaque.brightest}"
+                }
+              },
+              "secondary": {
+                "fallback": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.vacation.opaque.darkest}"
+                }
+              }
+            },
+            "supplemental": {
+              "primary": {
+                "fallback": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.vacation.opaque.darkest}"
+                }
+              },
+              "secondary": {
+                "fallback": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.vacation.opaque.brightest}"
+                }
+              }
+            }
+          },
+          "fantasy": {
+            "main": {
+              "primary": {
+                "fallback": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.fantasy.opaque.brightest}"
+                }
+              },
+              "secondary": {
+                "fallback": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.fantasy.opaque.darkest}"
+                }
+              }
+            },
+            "supplemental": {
+              "primary": {
+                "fallback": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.fantasy.opaque.darkest}"
+                }
+              },
+              "secondary": {
+                "fallback": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.fantasy.opaque.brightest}"
+                }
+              }
+            }
+          },
+          "thriller": {
+            "main": {
+              "primary": {
+                "fallback": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.thriller.opaque.brightest}"
+                }
+              },
+              "secondary": {
+                "fallback": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.thriller.opaque.darkest}"
+                }
+              }
+            },
+            "supplemental": {
+              "primary": {
+                "fallback": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.thriller.opaque.darkest}"
+                }
+              },
+              "secondary": {
+                "fallback": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.thriller.opaque.brightest}"
+                }
+              }
+            }
+          }
+        }
+      },
+      "icon": {
+        "size": {
+          "width": {
+            "small": {
+              "description": "",
+              "type": "color",
+              "value": "{regional.action.visual.icon.size.small}"
+            },
+            "regular": {
+              "description": "",
+              "type": "color",
+              "value": "{regional.action.visual.icon.size.regular}"
+            }
+          },
+          "height": {
+            "small": {
+              "description": "",
+              "type": "color",
+              "value": "{regional.action.visual.icon.size.small}"
+            },
+            "regular": {
+              "description": "",
+              "type": "color",
+              "value": "{regional.action.visual.icon.size.regular}"
+            }
+          }
+        },
+        "color": {
+          "carmine": {
+            "main": {
+              "primary": {
+                "fallback": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.carmine.opaque.brightest}"
+                }
+              },
+              "secondary": {
+                "fallback": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.carmine.opaque.darkest}"
+                }
+              }
+            },
+            "supplemental": {
+              "primary": {
+                "fallback": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.carmine.opaque.darkest}"
+                }
+              },
+              "secondary": {
+                "fallback": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.carmine.opaque.brightest}"
+                }
+              }
+            }
+          },
+          "aubergine": {
+            "main": {
+              "primary": {
+                "fallback": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.aubergine.opaque.dark}"
+                }
+              },
+              "secondary": {
+                "fallback": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.aubergine.opaque.dark}"
+                }
+              }
+            },
+            "supplemental": {
+              "primary": {
+                "fallback": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.aubergine.opaque.bright}"
+                }
+              },
+              "secondary": {
+                "fallback": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.aubergine.opaque.bright}"
+                }
+              }
+            },
+            "supplemental alt": {
+              "primary": {
+                "fallback": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.aubergine.opaque.darkest}"
+                }
+              }
+            }
+          },
+          "rettsdata": {
+            "main": {
+              "primary": {
+                "fallback": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.rettsdata.opaque.brightest}"
+                }
+              },
+              "secondary": {
+                "fallback": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.rettsdata.opaque.midtone}"
+                }
+              }
+            },
+            "supplemental": {
+              "primary": {
+                "fallback": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.rettsdata.opaque.midtone}"
+                }
+              },
+              "secondary": {
+                "fallback": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.rettsdata.opaque.brightest}"
+                }
+              }
+            },
+            "supplemental alt": {
+              "primary": {
+                "fallback": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.rettsdata.opaque.brightest}"
+                }
+              }
+            }
+          },
+          "neutral": {
+            "main": {
+              "primary": {
+                "fallback": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.neutral.opaque.darkest}"
+                }
+              },
+              "secondary": {
+                "fallback": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.neutral.opaque.darkest}"
+                }
+              }
+            },
+            "supplemental": {
+              "primary": {
+                "fallback": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.neutral.opaque.bright}"
+                }
+              },
+              "secondary": {
+                "fallback": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.neutral.opaque.bright}"
+                }
+              }
+            },
+            "supplemental alt": {
+              "primary": {
+                "fallback": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.neutral.opaque.brightest}"
+                }
+              }
+            }
+          },
+          "success": {
+            "main": {
+              "primary": {
+                "fallback": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.success.opaque.darkest}"
+                }
+              }
+            },
+            "supplemental": {
+              "primary": {
+                "fallback": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.success.opaque.brightest}"
+                }
+              }
+            }
+          },
+          "informative": {
+            "main": {
+              "primary": {
+                "fallback": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.informative.opaque.darkest}"
+                }
+              }
+            },
+            "supplemental": {
+              "primary": {
+                "fallback": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.informative.opaque.brightest}"
+                }
+              }
+            }
+          },
+          "warning": {
+            "main": {
+              "primary": {
+                "fallback": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.warning.opaque.darkest}"
+                }
+              }
+            },
+            "supplemental": {
+              "primary": {
+                "fallback": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.warning.opaque.brightest}"
+                }
+              }
+            }
+          },
+          "nostalgia": {
+            "main": {
+              "primary": {
+                "fallback": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.nostalgia.opaque.brightest}"
+                }
+              },
+              "secondary": {
+                "fallback": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.nostalgia.opaque.darkest}"
+                }
+              }
+            },
+            "supplemental": {
+              "primary": {
+                "fallback": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.nostalgia.opaque.darkest}"
+                }
+              },
+              "secondary": {
+                "fallback": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.nostalgia.opaque.brightest}"
+                }
+              }
+            }
+          },
+          "nature": {
+            "main": {
+              "primary": {
+                "fallback": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.nature.opaque.brightest}"
+                }
+              },
+              "secondary": {
+                "fallback": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.nature.opaque.darkest}"
+                }
+              }
+            },
+            "supplemental": {
+              "primary": {
+                "fallback": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.nature.opaque.darkest}"
+                }
+              },
+              "secondary": {
+                "fallback": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.nature.opaque.brightest}"
+                }
+              }
+            }
+          },
+          "romance": {
+            "main": {
+              "primary": {
+                "fallback": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.romance.opaque.brightest}"
+                }
+              },
+              "secondary": {
+                "fallback": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.romance.opaque.darkest}"
+                }
+              }
+            },
+            "supplemental": {
+              "primary": {
+                "fallback": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.romance.opaque.darkest}"
+                }
+              },
+              "secondary": {
+                "fallback": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.romance.opaque.brightest}"
+                }
+              }
+            }
+          },
+          "thriller": {
+            "main": {
+              "primary": {
+                "fallback": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.thriller.opaque.brightest}"
+                }
+              },
+              "secondary": {
+                "fallback": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.thriller.opaque.darkest}"
+                }
+              }
+            },
+            "supplemental": {
+              "primary": {
+                "fallback": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.thriller.opaque.darkest}"
+                }
+              },
+              "secondary": {
+                "fallback": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.thriller.opaque.brightest}"
+                }
+              }
+            }
+          },
+          "fantasy": {
+            "main": {
+              "primary": {
+                "fallback": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.fantasy.opaque.brightest}"
+                }
+              },
+              "secondary": {
+                "fallback": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.fantasy.opaque.darkest}"
+                }
+              }
+            },
+            "supplemental": {
+              "primary": {
+                "fallback": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.fantasy.opaque.darkest}"
+                }
+              },
+              "secondary": {
+                "fallback": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.fantasy.opaque.brightest}"
+                }
+              }
+            }
+          },
+          "vacation": {
+            "main": {
+              "primary": {
+                "fallback": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.vacation.opaque.brightest}"
+                }
+              },
+              "secondary": {
+                "fallback": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.vacation.opaque.darkest}"
+                }
+              }
+            },
+            "supplemental": {
+              "primary": {
+                "fallback": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.vacation.opaque.darkest}"
+                }
+              },
+              "secondary": {
+                "fallback": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.action.color.vacation.opaque.brightest}"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "input": {
+      "textual": {
+        "label": {
+          "color": {
+            "main": {
+              "fallback": {
+                "description": "Textual means type text, password, search, email, tel, url",
+                "type": "color",
+                "value": "{regional.form.color.base.midtone}"
+              },
+              "active": {
+                "description": "Textual means type text, password, search, email, tel, url",
+                "type": "color",
+                "value": "{regional.form.color.base.darker}"
+              }
+            },
+            "supplement": {
+              "fallback": {
+                "description": "Textual means type text, password, search, email, tel, url",
+                "type": "color",
+                "value": "{regional.form.color.base.bright}"
+              },
+              "active": {
+                "description": "Textual means type text, password, search, email, tel, url",
+                "type": "color",
+                "value": "{regional.form.color.base.dark}"
+              }
+            }
+          }
+        },
+        "input-text": {
+          "color": {
+            "primary": {
+              "fallback": {
+                "description": "Textual means type text, password, search, email, tel, url",
+                "type": "color",
+                "value": "{regional.form.color.base.darker}"
+              }
+            },
+            "secondary": {
+              "fallback": {
+                "description": "Textual means type text, password, search, email, tel, url",
+                "type": "color",
+                "value": "{regional.form.color.base.bright}"
+              }
+            }
+          }
+        },
+        "supportive-text": {
+          "color": {
+            "primary": {
+              "fallback": {
+                "description": "Textual means type text, password, search, email, tel, url",
+                "type": "color",
+                "value": "{regional.form.color.base.darker}"
+              }
+            },
+            "secondary": {
+              "fallback": {
+                "description": "Textual means type text, password, search, email, tel, url",
+                "type": "color",
+                "value": "{regional.form.color.base.bright}"
+              }
+            }
+          }
+        },
+        "background": {
+          "color": {
+            "primary": {
+              "hover": {
+                "description": "",
+                "type": "color",
+                "value": "{regional.form.color.base.brighter}"
+              },
+              "active": {
+                "description": "",
+                "type": "color",
+                "value": "{regional.form.color.base.brighter}"
+              }
+            },
+            "secondary": {
+              "hover": {
+                "description": "",
+                "type": "color",
+                "value": "{regional.form.color.base.darker}"
+              },
+              "active": {
+                "description": "",
+                "type": "color",
+                "value": "{regional.form.color.base.darker}"
+              }
+            }
+          }
+        },
+        "container": {
+          "border-bottom": {
+            "color": {
+              "supplemental": {
+                "fallback": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.form.color.base.dark}"
+                }
+              },
+              "main": {
+                "fallback": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.form.color.base.darker}"
+                }
+              }
+            },
+            "width": {
+              "fallback": {
+                "description": "",
+                "type": "color",
+                "value": "{regional.form.stroke.regular}"
+              },
+              "active": {
+                "description": "",
+                "type": "color",
+                "value": "{regional.form.stroke.thick}"
+              }
+            }
+          },
+          "padding": {
+            "description": "",
+            "type": "color",
+            "value": "{regional.form.space.small}"
+          },
+          "gap": {
+            "description": "",
+            "type": "color",
+            "value": "{regional.form.space.small}"
+          }
+        },
+        "icon": {
+          "color": {
+            "supplemental": {
+              "fallback": {
+                "description": "",
+                "type": "color",
+                "value": "{regional.form.color.base.bright}"
+              }
+            },
+            "main": {
+              "fallback": {
+                "description": "",
+                "type": "color",
+                "value": "{regional.form.color.base.darker}"
+              }
+            }
+          }
+        },
+        "wrapper": {
+          "gap": {
+            "description": "",
+            "type": "color",
+            "value": "{regional.form.space.xsmall}"
+          },
+          "padding": {
+            "description": "",
+            "type": "color",
+            "value": "{regional.form.space.xsmall}"
+          }
+        },
+        "inner-container": {
+          "gap": {
+            "description": "",
+            "type": "color",
+            "value": "{regional.action.space.xsmall}"
+          }
+        }
+      },
+      "selection": {
+        "label": {
+          "color": {
+            "fallback": {
+              "description": "",
+              "type": "color",
+              "value": "{regional.form.color.base.darker}"
+            }
+          }
+        },
+        "radio-indicator": {
+          "outline": {
+            "radius": {
+              "description": "",
+              "type": "color",
+              "value": "{regional.form.radius.pill}"
+            },
+            "width": {
+              "description": "",
+              "type": "color",
+              "value": "{regional.form.stroke.fat}"
+            },
+            "color": {
+              "success": {
+                "hover": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.form.color.extended.brightest}"
+                },
+                "active": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.form.color.extended.midtone}"
+                }
+              },
+              "aubergine": {
+                "hover": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.form.color.base.brightest}"
+                },
+                "active": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.form.color.base.bright}"
+                }
+              }
+            }
+          },
+          "border": {
+            "radius": {
+              "description": "",
+              "type": "color",
+              "value": "{regional.form.radius.pill}"
+            },
+            "width": {
+              "description": "",
+              "type": "color",
+              "value": "{regional.form.stroke.regular}"
+            },
+            "color": {
+              "success": {
+                "fallback": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.form.color.extended.darkest}"
+                }
+              },
+              "aubergine": {
+                "fallback": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.form.color.base.darkest}"
+                }
+              }
+            }
+          },
+          "icon": {
+            "color": {
+              "success": {
+                "fallback": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.form.color.extended.darkest}"
+                }
+              },
+              "aubergine": {
+                "fallback": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.form.color.base.darkest}"
+                }
+              }
+            }
+          },
+          "container": {
+            "height": {
+              "description": "",
+              "type": "color",
+              "value": "{regional.action.size.small}"
+            },
+            "width": {
+              "description": "",
+              "type": "color",
+              "value": "{regional.action.size.small}"
+            }
+          }
+        },
+        "checkmark-indicator": {
+          "outline": {
+            "radius": {
+              "description": "",
+              "type": "color",
+              "value": "{regional.action.radius.small}"
+            },
+            "width": {
+              "description": "",
+              "type": "color",
+              "value": "{regional.form.stroke.fat}"
+            },
+            "color": {
+              "success": {
+                "hover": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.form.color.extended.brightest}"
+                },
+                "active": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.form.color.extended.midtone}"
+                }
+              },
+              "aubergine": {
+                "hover": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.form.color.base.brightest}"
+                },
+                "active": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.form.color.base.bright}"
+                }
+              }
+            }
+          },
+          "border": {
+            "radius": {
+              "description": "",
+              "type": "color",
+              "value": "{regional.form.radius.large}"
+            },
+            "width": {
+              "description": "",
+              "type": "color",
+              "value": "{regional.form.stroke.regular}"
+            },
+            "color": {
+              "success": {
+                "idle": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.form.color.extended.darkest}"
+                },
+                "hover": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.form.color.extended.darkest}"
+                },
+                "active": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.form.color.extended.darkest}"
+                },
+                "focus": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.form.color.extended.darkest}"
+                }
+              },
+              "aubergine": {
+                "idle": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.form.color.base.darkest}"
+                },
+                "hover": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.form.color.base.darkest}"
+                },
+                "active": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.form.color.base.darkest}"
+                },
+                "focus": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.form.color.base.darkest}"
+                }
+              }
+            }
+          },
+          "icon": {
+            "color": {
+              "success": {
+                "fallback": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.form.color.extended.darkest}"
+                }
+              },
+              "aubergine": {
+                "fallback": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.form.color.base.darkest}"
+                }
+              }
+            }
+          },
+          "background": {
+            "color": {
+              "success": {
+                "idle": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.form.color.extended.brightest}"
+                },
+                "disabled": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.form.color.extended.midtone}"
+                }
+              },
+              "aubergine": {
+                "idle": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.form.color.base.brightest}"
+                },
+                "disabled": {
+                  "description": "",
+                  "type": "color",
+                  "value": "{regional.form.color.base.bright}"
+                }
+              }
+            }
+          },
+          "container": {
+            "height": {
+              "description": "",
+              "type": "color",
+              "value": "{regional.action.size.medium}"
+            },
+            "width": {
+              "description": "",
+              "type": "color",
+              "value": "{regional.action.size.medium}"
+            }
+          }
+        },
+        "wrapper": {
+          "padding": {
+            "description": "",
+            "type": "color",
+            "value": "{regional.form.space.xsmall}"
+          }
+        },
+        "container": {
+          "gap": {
+            "description": "",
+            "type": "color",
+            "value": "{regional.form.space.medium}"
+          }
+        },
+        "inner-container-left": {
+          "gap": {
+            "description": "",
+            "type": "color",
+            "value": "{regional.form.space.medium}"
+          }
+        }
+      }
+    },
+    "divider": {
+      "background": {
+        "color": {
+          "main": {
+            "description": "",
+            "type": "color",
+            "value": "{regional.structural.color.brightest}"
+          },
+          "supplemental": {
+            "description": "",
+            "type": "color",
+            "value": "{regional.structural.color.darkest}"
+          }
+        }
+      },
+      "container": {
+        "radius": {
+          "description": "",
+          "type": "color",
+          "value": "{regional.structural.radius}"
+        },
+        "padding": {
+          "block": {
+            "horizontal": {
+              "description": "",
+              "type": "color",
+              "value": "{regional.structural.space}"
+            }
+          },
+          "inline": {
+            "vertical": {
+              "description": "",
+              "type": "color",
+              "value": "{regional.structural.space}"
+            }
+          }
+        },
+        "height": {
+          "horizontal": {
+            "description": "",
+            "type": "color",
+            "value": "{regional.structural.stroke}"
+          }
+        },
+        "width": {
+          "vertical": {
+            "description": "",
+            "type": "color",
+            "value": "{regional.structural.stroke}"
+          }
+        }
+      }
+    },
+    "docs-list-item": {
+      "text": {
+        "color": {
+          "description": "",
+          "type": "color",
+          "value": "{regional.data-display.color.darker}"
+        }
+      },
+      "container": {
+        "border": {
+          "radius": {
+            "description": "",
+            "type": "color",
+            "value": "{regional.data-display.radius}"
+          }
+        },
+        "size": {
+          "height": {
+            "description": "",
+            "type": "color",
+            "value": "{regional.data-display.size}"
+          }
+        },
+        "gap": {
+          "description": "",
+          "type": "color",
+          "value": "{regional.data-display.space.small}"
+        },
+        "padding": {
+          "top": {
+            "description": "",
+            "type": "color",
+            "value": "{regional.data-display.space.medium}"
+          },
+          "right": {
+            "description": "",
+            "type": "color",
+            "value": "{regional.data-display.space.medium}"
+          },
+          "bottom": {
+            "description": "",
+            "type": "color",
+            "value": "{regional.data-display.space.medium}"
+          },
+          "left": {
+            "description": "",
+            "type": "color",
+            "value": "{regional.data-display.space.medium}",
+            "nested": {
+              "description": "",
+              "type": "color",
+              "value": "{regional.data-display.space.xlarge}"
+            }
+          }
+        }
+      },
+      "background": {
+        "color": {
+          "hover": {
+            "description": "",
+            "type": "color",
+            "value": "{regional.data-display.color.midtone}"
+          }
+        }
+      },
+      "border-bottom": {
+        "color": {
+          "active": {
+            "description": "",
+            "type": "color",
+            "value": "{regional.data-display.color.darker}"
+          }
+        },
+        "width": {
+          "active": {
+            "description": "",
+            "type": "color",
+            "value": "{regional.data-display.stroke}"
+          }
+        },
+        "padding": {
+          "top": {
+            "description": "",
+            "type": "color",
+            "value": "{regional.data-display.space.tiny}"
+          }
+        }
+      },
+      "icon": {
+        "color": {
+          "description": "",
+          "type": "color",
+          "value": "{regional.data-display.color.darker}"
+        }
+      }
+    },
+    "docs-side-menu": {
+      "container": {
+        "padding": {
+          "description": "",
+          "type": "color",
+          "value": "{regional.navigation.space.small}"
+        },
+        "gap": {
+          "description": "",
+          "type": "color",
+          "value": "{regional.navigation.space.small}"
+        }
+      }
+    },
+    "docs-navbar-item": {
+      "text": {
+        "color": {
+          "main": {
+            "description": "",
+            "type": "color",
+            "value": "{regional.navigation.color.dark}"
+          },
+          "supplemental": {
+            "description": "",
+            "type": "color",
+            "value": "{regional.navigation.color.brightest}"
+          }
+        }
+      },
+      "border-bottom": {
+        "width": {
+          "description": "",
+          "type": "color",
+          "value": "{regional.navigation.stroke}"
+        },
+        "color": {
+          "main": {
+            "hover": {
+              "description": "",
+              "type": "color",
+              "value": "{regional.navigation.color.dark}"
+            },
+            "active": {
+              "description": "",
+              "type": "color",
+              "value": "{regional.navigation.color.dark}"
+            }
+          },
+          "supportive": {
+            "hover": {
+              "description": "",
+              "type": "color",
+              "value": "{regional.navigation.color.brightest}"
+            },
+            "active": {
+              "description": "",
+              "type": "color",
+              "value": "{regional.navigation.color.brightest}"
+            }
+          }
+        }
+      }
+    },
+    "docs-navbar": {
+      "background": {
+        "color": {
+          "main": {
+            "description": "",
+            "type": "color",
+            "value": "{regional.navigation.color.brightest}"
+          },
+          "supplemental": {
+            "description": "",
+            "type": "color",
+            "value": "{regional.navigation.color.darkest}"
+          }
+        }
+      },
+      "text": {
+        "main": {
+          "description": "",
+          "type": "color",
+          "value": "{regional.navigation.color.brightest}"
+        },
+        "supplemental": {
+          "description": "",
+          "type": "color",
+          "value": "{regional.navigation.color.darkest}"
+        }
+      },
+      "container": {
+        "padding": {
+          "block": {
+            "description": "",
+            "type": "color",
+            "value": "{regional.navigation.space.medium}"
+          }
+        },
+        "gap": {
+          "mobile": {
+            "description": "",
+            "type": "color",
+            "value": "{regional.navigation.space.xxlarge}"
+          }
+        }
+      }
+    },
+    "heading": {
+      "padding": {
+        "bottom": {
+          "description": "",
+          "type": "color",
+          "value": "{global.typography.space.small}"
+        }
+      },
+      "text": {
+        "color": {
+          "base": {
+            "description": "",
+            "type": "color",
+            "value": "{global.typography.color.dark}"
+          },
+          "highlight": {
+            "description": "",
+            "type": "color",
+            "value": "{global.typography.color.brand}"
+          }
+        }
+      }
+    },
+    "body": {
+      "text": {
+        "color": {
+          "base": {
+            "description": "",
+            "type": "color",
+            "value": "{global.typography.color.darkest}"
+          },
+          "highlight": {
+            "description": "",
+            "type": "color",
+            "value": "{global.typography.color.brand}"
+          }
+        }
+      }
+    },
+    "link": {
+      "container": {
+        "gap": {
+          "description": "",
+          "type": "color",
+          "value": "{regional.navigation.space.small}"
+        },
+        "border": {
+          "width": {
+            "hover": {
+              "description": "",
+              "type": "color",
+              "value": "{regional.navigation.stroke}"
+            },
+            "action": {
+              "description": "",
+              "type": "color",
+              "value": "{regional.navigation.stroke}"
+            }
+          },
+          "color": {
+            "hover": {
+              "description": "",
+              "type": "color",
+              "value": "{regional.navigation.color.midtone}"
+            },
+            "action": {
+              "description": "",
+              "type": "color",
+              "value": "{regional.navigation.color.midtone}"
+            }
+          }
+        }
+      },
+      "icon": {
+        "size": {
+          "description": "",
+          "type": "color",
+          "value": "{regional.navigation.visual.icon.size}"
+        },
+        "color": {
+          "description": "",
+          "type": "color",
+          "value": "{regional.navigation.color.midtone}"
+        }
+      },
+      "text": {
+        "color": {
+          "description": "",
+          "type": "color",
+          "value": "{regional.navigation.color.midtone}"
+        }
+      }
+    },
+    "feature-box": {
+      "container": {
+        "padding": {
+          "description": "",
+          "type": "color",
+          "value": "{regional.action.space.medium}"
+        }
+      }
+    },
+    "alert": {
+      "background": {
+        "color": {
+          "success": {
+            "description": "",
+            "type": "color",
+            "value": "{regional.feedback.color.success.brightest}"
+          },
+          "info": {
+            "description": "",
+            "type": "color",
+            "value": "{regional.feedback.color.info.brightest}"
+          },
+          "warning": {
+            "description": "",
+            "type": "color",
+            "value": "{regional.feedback.color.warning.brightest}"
+          }
+        }
+      },
+      "text": {
+        "color": {
+          "success": {
+            "description": "",
+            "type": "color",
+            "value": "{regional.feedback.color.success.darkest}"
+          },
+          "info": {
+            "description": "",
+            "type": "color",
+            "value": "{regional.feedback.color.info.darkest}"
+          },
+          "warning": {
+            "description": "",
+            "type": "color",
+            "value": "{regional.feedback.color.warning.darkest}"
+          }
+        }
+      },
+      "icon": {
+        "color": {
+          "success": {
+            "description": "",
+            "type": "color",
+            "value": "{regional.feedback.color.success.darkest}"
+          },
+          "info": {
+            "description": "",
+            "type": "color",
+            "value": "{regional.feedback.color.info.darkest}"
+          },
+          "warning": {
+            "description": "",
+            "type": "color",
+            "value": "{regional.feedback.color.warning.darkest}"
+          }
+        },
+        "size": {
+          "label": {
+            "description": "",
+            "type": "color",
+            "value": "{regional.feedback.visual.icon.size.small}"
+          },
+          "accordion": {
+            "description": "",
+            "type": "color",
+            "value": "{regional.feedback.visual.icon.size.regular}"
+          },
+          "banner": {
+            "description": "",
+            "type": "color",
+            "value": "{regional.feedback.visual.icon.size.regular}"
+          }
+        }
+      },
+      "container": {
+        "padding": {
+          "top": {
+            "label": {
+              "description": "",
+              "type": "color",
+              "value": "{regional.feedback.space.small}"
+            },
+            "banner": {
+              "description": "",
+              "type": "color",
+              "value": "{regional.feedback.space.small}"
+            },
+            "accordion": {
+              "description": "",
+              "type": "color",
+              "value": "{regional.feedback.space.large}"
+            }
+          },
+          "right": {
+            "label": {
+              "description": "",
+              "type": "color",
+              "value": "{regional.feedback.space.small}"
+            },
+            "banner": {
+              "description": "",
+              "type": "color",
+              "value": "{regional.feedback.space.small}"
+            },
+            "accordion": {
+              "description": "",
+              "type": "color",
+              "value": "{regional.feedback.space.large}"
+            }
+          },
+          "bottom": {
+            "label": {
+              "description": "",
+              "type": "color",
+              "value": "{regional.feedback.space.small}"
+            },
+            "banner": {
+              "description": "",
+              "type": "color",
+              "value": "{regional.feedback.space.small}"
+            },
+            "accordion": {
+              "description": "",
+              "type": "color",
+              "value": "{regional.feedback.space.large}"
+            }
+          },
+          "left": {
+            "label": {
+              "description": "",
+              "type": "color",
+              "value": "{regional.feedback.space.small}"
+            },
+            "banner": {
+              "description": "",
+              "type": "color",
+              "value": "{regional.feedback.space.large}"
+            },
+            "accordion": {
+              "description": "",
+              "type": "color",
+              "value": "{regional.feedback.space.large}"
+            }
+          }
+        },
+        "gap": {
+          "label": {
+            "description": "",
+            "type": "color",
+            "value": "{regional.feedback.space.xsmall}"
+          }
+        },
+        "border": {
+          "radius": {
+            "label": {
+              "description": "",
+              "type": "color",
+              "value": "{regional.feedback.radius.small}"
+            },
+            "banner": {
+              "description": "",
+              "type": "color",
+              "value": "{regional.feedback.radius.medium}"
+            },
+            "accordion": {
+              "description": "",
+              "type": "color",
+              "value": "{regional.feedback.radius.medium}"
+            }
+          }
+        }
+      },
+      "inner-container-left": {
+        "gap": {
+          "banner": {
+            "description": "",
+            "type": "color",
+            "value": "{regional.feedback.space.medium}"
+          },
+          "accordion": {
+            "vertical": {
+              "description": "",
+              "type": "color",
+              "value": "{regional.feedback.space.medium}"
+            },
+            "horizontal": {
+              "description": "",
+              "type": "color",
+              "value": "{regional.feedback.space.xlarge}"
+            }
+          }
+        }
+      },
+      "inner-container-right": {
+        "padding": {
+          "right": {
+            "description": "",
+            "type": "color",
+            "value": "{regional.feedback.space.small}"
+          }
+        }
+      }
+    },
+    "ingress": {
+      "text": {
+        "color": {
+          "base": {
+            "description": "",
+            "type": "color",
+            "value": "{global.typography.color.darkest}"
+          },
+          "highlight": {
+            "description": "",
+            "type": "color",
+            "value": "{global.typography.color.brand}"
+          }
+        }
+      }
+    },
+    "meta-text": {
+      "text": {
+        "color": {
+          "base": {
+            "description": "",
+            "type": "color",
+            "value": "{global.typography.color.midtone}"
+          },
+          "highlight": {
+            "description": "",
+            "type": "color",
+            "value": "{global.typography.color.brand}"
+          },
+          "extended": {
+            "description": "",
+            "type": "color",
+            "value": "{global.typography.color.bright}"
+          }
+        }
+      }
+    },
+    "kicker-text": {
+      "text": {
+        "color": {
+          "base": {
+            "description": "",
+            "type": "color",
+            "value": "{global.typography.color.bright}"
+          }
+        }
+      }
+    },
+    "text-link": {
+      "container": {
+        "gap": {
+          "description": "",
+          "type": "color",
+          "value": "{regional.navigation.space.small}"
+        },
+        "border": {
+          "width": {
+            "description": "",
+            "type": "color",
+            "value": "{regional.navigation.stroke}"
+          },
+          "color": {
+            "description": "",
+            "type": "color",
+            "value": "{regional.navigation.color.midtone}"
+          }
+        }
+      },
+      "text": {
+        "color": {
+          "description": "",
+          "type": "color",
+          "value": "{regional.navigation.color.midtone}"
+        }
+      }
+    }
+  },
+  "universal": {
+    "focus": {
+      "border": {
+        "radius": {
+          "xsmall": {
+            "description": "",
+            "type": "color",
+            "value": "{global.layout.element.radius.xsmall}"
+          },
+          "small": {
+            "description": "",
+            "type": "color",
+            "value": "{global.layout.element.radius.small}"
+          },
+          "medium": {
+            "description": "",
+            "type": "color",
+            "value": "{global.layout.element.radius.medium}"
+          },
+          "large": {
+            "description": "",
+            "type": "color",
+            "value": "{global.layout.element.radius.large}"
+          },
+          "xlarge": {
+            "description": "",
+            "type": "color",
+            "value": "{global.layout.element.radius.xlarge}"
+          },
+          "pill": {
+            "description": "",
+            "type": "color",
+            "value": "{global.layout.element.radius.pill}"
+          }
+        },
+        "width": {
+          "description": "",
+          "type": "color",
+          "value": "{global.layout.element.stroke.thick}"
+        }
+      },
+      "color": {
+        "description": "",
+        "type": "color",
+        "value": "{global.color.ui.informative.informative-450}"
+      }
+    },
+    "text": {
+      "primary": {
+        "size": {
+          "display": {
+            "large": {
+              "description": "",
+              "type": "color",
+              "value": "{global.typography.size.64}"
+            },
+            "medium": {
+              "description": "",
+              "type": "color",
+              "value": "{global.typography.size.56}"
+            },
+            "small": {
+              "description": "",
+              "type": "color",
+              "value": "{global.typography.size.48}"
+            }
+          },
+          "heading": {
+            "small": {
+              "description": "",
+              "type": "color",
+              "value": "{global.typography.size.32}"
+            },
+            "medium": {
+              "description": "",
+              "type": "color",
+              "value": "{global.typography.size.40}"
+            }
+          },
+          "title": {
+            "small": {
+              "description": "",
+              "type": "color",
+              "value": "{global.typography.size.20}"
+            },
+            "medium": {
+              "description": "",
+              "type": "color",
+              "value": "{global.typography.size.24}"
+            }
+          },
+          "body": {
+            "description": "",
+            "type": "color",
+            "value": "{global.typography.size.16}"
+          },
+          "label": {
+            "small": {
+              "description": "",
+              "type": "color",
+              "value": "{global.typography.size.12}"
+            },
+            "medium": {
+              "description": "",
+              "type": "color",
+              "value": "{global.typography.size.14}"
+            }
+          }
+        },
+        "line-height": {
+          "display": {
+            "large": {
+              "description": "",
+              "type": "color",
+              "value": "{global.typography.line-height.80}"
+            },
+            "medium": {
+              "description": "",
+              "type": "color",
+              "value": "{global.typography.line-height.70}"
+            },
+            "small": {
+              "description": "",
+              "type": "color",
+              "value": "{global.typography.line-height.60}"
+            }
+          },
+          "body": {
+            "description": "",
+            "type": "color",
+            "value": "{global.typography.line-height.25}"
+          },
+          "label": {
+            "small": {
+              "description": "",
+              "type": "color",
+              "value": "{global.typography.line-height.20}"
+            },
+            "medium": {
+              "description": "",
+              "type": "color",
+              "value": "{global.typography.line-height.25}"
+            }
+          },
+          "heading": {
+            "small": {
+              "description": "",
+              "type": "color",
+              "value": "{global.typography.line-height.50}"
+            },
+            "medium": {
+              "description": "",
+              "type": "color",
+              "value": "{global.typography.line-height.60}"
+            }
+          },
+          "title": {
+            "small": {
+              "description": "",
+              "type": "color",
+              "value": "{global.typography.line-height.35}"
+            },
+            "medium": {
+              "description": "",
+              "type": "color",
+              "value": "{global.typography.line-height.40}"
+            }
+          }
+        },
+        "weight": {
+          "display": {
+            "small": {
+              "small": {
+                "description": "",
+                "type": "color",
+                "value": "{global.typography.weight.book}"
+              }
+            },
+            "large": {
+              "large": {
+                "description": "",
+                "type": "color",
+                "value": "{global.typography.weight.regular}"
+              }
+            },
+            "medium": {
+              "medium": {
+                "description": "",
+                "type": "color",
+                "value": "{global.typography.weight.book}"
+              }
+            }
+          },
+          "heading": {
+            "small": {
+              "small": {
+                "description": "",
+                "type": "color",
+                "value": "{global.typography.weight.regular}"
+              }
+            },
+            "medium": {
+              "medium": {
+                "description": "",
+                "type": "color",
+                "value": "{global.typography.weight.book}"
+              }
+            }
+          },
+          "title": {
+            "small": {
+              "small": {
+                "description": "",
+                "type": "color",
+                "value": "{global.typography.weight.regular}"
+              }
+            },
+            "medium": {
+              "medium": {
+                "description": "",
+                "type": "color",
+                "value": "{global.typography.weight.regular}"
+              }
+            }
+          },
+          "label": {
+            "small": {
+              "small": {
+                "description": "",
+                "type": "color",
+                "value": "{global.typography.weight.regular}"
+              }
+            },
+            "medium": {
+              "medium": {
+                "description": "",
+                "type": "color",
+                "value": "{global.typography.weight.regular}"
+              }
+            }
+          },
+          "body": {
+            "description": "",
+            "type": "color",
+            "value": "{global.typography.weight.regular}"
+          }
+        },
+        "font-familty": {
+          "description": "",
+          "type": "color",
+          "value": "{global.typography.font-family.pp-mori}"
+        }
+      },
+      "secondary": {
+        "font-familty": {
+          "description": "",
+          "type": "color",
+          "value": "{global.typography.font-family.lyon-display}"
+        },
+        "line-height": {
+          "display": {
+            "large": {
+              "description": "",
+              "type": "color",
+              "value": "{global.typography.line-height.80}"
+            },
+            "medium": {
+              "description": "",
+              "type": "color",
+              "value": "{global.typography.line-height.70}"
+            },
+            "small": {
+              "description": "",
+              "type": "color",
+              "value": "{global.typography.line-height.60}"
+            }
+          },
+          "heading": {
+            "medium": {
+              "description": "",
+              "type": "color",
+              "value": "{global.typography.line-height.50}"
+            },
+            "small": {
+              "description": "",
+              "type": "color",
+              "value": "{global.typography.line-height.40}"
+            }
+          }
+        },
+        "size": {
+          "display": {
+            "large": {
+              "description": "",
+              "type": "color",
+              "value": "{global.typography.size.64}"
+            },
+            "medium": {
+              "description": "",
+              "type": "color",
+              "value": "{global.typography.size.56}"
+            },
+            "small": {
+              "description": "",
+              "type": "color",
+              "value": "{global.typography.size.48}"
+            }
+          },
+          "heading": {
+            "small": {
+              "description": "",
+              "type": "color",
+              "value": "{global.typography.size.32}"
+            },
+            "medium": {
+              "description": "",
+              "type": "color",
+              "value": "{global.typography.size.40}"
+            }
+          }
+        },
+        "weight": {
+          "display": {
+            "small": {
+              "description": "",
+              "type": "color",
+              "value": "{global.typography.weight.light}"
+            },
+            "large": {
+              "description": "",
+              "type": "color",
+              "value": "{global.typography.weight.light}"
+            },
+            "medium": {
+              "description": "",
+              "type": "color",
+              "value": "{global.typography.weight.light}"
+            }
+          },
+          "heading": {
+            "small": {
+              "description": "",
+              "type": "color",
+              "value": "{global.typography.weight.light}"
+            },
+            "medium": {
+              "description": "",
+              "type": "color",
+              "value": "{global.typography.weight.regular}"
+            }
+          }
+        }
+      },
+      "reading": {
+        "font-familty": {
+          "description": "",
+          "type": "color",
+          "value": "{global.typography.font-family.inter}"
+        },
+        "line-height": {
+          "body": {
+            "description": "",
+            "type": "color",
+            "value": "{global.typography.line-height.25}"
+          },
+          "heading": {
+            "medium": {
+              "description": "",
+              "type": "color",
+              "value": "{global.typography.line-height.50}"
+            },
+            "small": {
+              "description": "",
+              "type": "color",
+              "value": "{global.typography.line-height.40}"
+            }
+          },
+          "title": {
+            "medium": {
+              "description": "",
+              "type": "color",
+              "value": "{global.typography.line-height.35}"
+            },
+            "small": {
+              "description": "",
+              "type": "color",
+              "value": "{global.typography.line-height.30}"
+            }
+          },
+          "label": {
+            "medium": {
+              "description": "",
+              "type": "color",
+              "value": "{global.typography.line-height.20}"
+            },
+            "small": {
+              "description": "",
+              "type": "color",
+              "value": "{global.typography.line-height.20}"
+            }
+          }
+        },
+        "size": {
+          "body": {
+            "description": "",
+            "type": "color",
+            "value": "{global.typography.size.16}"
+          },
+          "heading": {
+            "small": {
+              "description": "",
+              "type": "color",
+              "value": "{global.typography.size.32}"
+            },
+            "medium": {
+              "description": "",
+              "type": "color",
+              "value": "{global.typography.size.40}"
+            }
+          },
+          "title": {
+            "small": {
+              "description": "",
+              "type": "color",
+              "value": "{global.typography.size.20}"
+            },
+            "medium": {
+              "description": "",
+              "type": "color",
+              "value": "{global.typography.size.24}"
+            }
+          },
+          "label": {
+            "small": {
+              "description": "",
+              "type": "color",
+              "value": "{global.typography.size.12}"
+            },
+            "medium": {
+              "description": "",
+              "type": "color",
+              "value": "{global.typography.size.14}"
+            }
+          }
+        },
+        "weight": {
+          "body": {
+            "description": "",
+            "type": "color",
+            "value": "{global.typography.weight.regular}"
+          },
+          "heading": {
+            "small": {
+              "description": "",
+              "type": "color",
+              "value": "{global.typography.weight.regular}"
+            },
+            "medium": {
+              "description": "",
+              "type": "color",
+              "value": "{global.typography.weight.book}"
+            }
+          },
+          "title": {
+            "small": {
+              "description": "",
+              "type": "color",
+              "value": "{global.typography.weight.regular}"
+            },
+            "medium": {
+              "description": "",
+              "type": "color",
+              "value": "{global.typography.weight.regular}"
+            }
+          },
+          "label": {
+            "small": {
+              "description": "",
+              "type": "color",
+              "value": "{global.typography.weight.regular}"
+            },
+            "medium": {
+              "description": "",
+              "type": "color",
+              "value": "{global.typography.weight.regular}"
+            }
+          }
+        }
+      },
+      "ui": {
+        "font-familty": {
+          "description": "",
+          "type": "color",
+          "value": "{global.typography.font-family.pp-mori}"
+        },
+        "size": {
+          "input": {
+            "description": "",
+            "type": "color",
+            "value": "{global.typography.size.16}"
+          },
+          "button": {
+            "description": "",
+            "type": "color",
+            "value": "{global.typography.size.16}"
+          },
+          "label": {
+            "medium": {
+              "description": "",
+              "type": "color",
+              "value": "{global.typography.size.14}"
+            },
+            "small": {
+              "description": "",
+              "type": "color",
+              "value": "{global.typography.size.12}"
+            },
+            "large": {
+              "description": "",
+              "type": "color",
+              "value": "{global.typography.size.16}"
+            }
+          }
+        },
+        "line-height": {
+          "input": {
+            "description": "",
+            "type": "color",
+            "value": "{global.typography.line-height.25}"
+          },
+          "label": {
+            "medium": {
+              "multi-line": {
+                "description": "",
+                "type": "color",
+                "value": "{global.typography.line-height.25}"
+              }
+            },
+            "small": {
+              "multi-line": {
+                "description": "",
+                "type": "color",
+                "value": "{global.typography.line-height.20}"
+              }
+            },
+            "large": {
+              "multi-line": {
+                "description": "",
+                "type": "color",
+                "value": "{global.typography.line-height.25}"
+              }
+            }
+          }
+        },
+        "weight": {
+          "input": {
+            "description": "",
+            "type": "color",
+            "value": "{global.typography.weight.regular}"
+          },
+          "button": {
+            "description": "",
+            "type": "color",
+            "value": "{global.typography.weight.regular}"
+          },
+          "label": {
+            "small": {
+              "description": "",
+              "type": "color",
+              "value": "{global.typography.weight.regular}"
+            },
+            "medium": {
+              "description": "",
+              "type": "color",
+              "value": "{global.typography.weight.regular}"
+            },
+            "large": {
+              "description": "",
+              "type": "color",
+              "value": "{global.typography.weight.regular}"
+            }
+          }
+        }
+      }
+    },
+    "disabled": {
+      "container": {
+        "opacity": {
+          "description": "",
+          "type": "dimension",
+          "value": "{primitives.transparency.50}"
+        }
+      }
+    },
+    "hover": {
+      "container": {
+        "lighten": {
+          "description": "",
+          "type": "color",
+          "value": "{global.color.identity.base.aubergine-1000}"
+        },
+        "darken": {
+          "description": "",
+          "type": "color",
+          "value": "{global.color.identity.base.aubergine-50}"
+        },
+        "opacity": {
+          "description": "",
+          "type": "dimension",
+          "value": "{primitives.transparency.10}"
+        }
+      }
+    }
+  },
+  "layout": {
+    "text-wrapper": {
+      "gap": {
+        "horizontal": {
+          "description": "",
+          "type": "color",
+          "value": "{global.typography.space.medium}"
+        }
+      }
+    },
+    "main": {
+      "gap": {
+        "min": {
+          "description": "",
+          "type": "color",
+          "value": "{global.layout.page.space.xxsmall}"
+        },
+        "max": {
+          "description": "",
+          "type": "color",
+          "value": "{global.layout.page.space.small}"
+        }
+      },
+      "padding": {
+        "min": {
+          "description": "",
+          "type": "color",
+          "value": "{global.layout.page.space.xxsmall}"
+        },
+        "max": {
+          "description": "",
+          "type": "color",
+          "value": "{global.layout.page.space.small}"
+        }
+      },
+      "width": {
+        "min": {
+          "description": "",
+          "type": "color",
+          "value": "{global.layout.page.width.min}"
+        },
+        "max": {
+          "description": "",
+          "type": "color",
+          "value": "{global.layout.page.width.max}"
+        }
+      }
+    },
+    "page": {
+      "gap": {
+        "min": {
+          "description": "",
+          "type": "color",
+          "value": "{global.layout.page.space.xxsmall}"
+        },
+        "max": {
+          "description": "",
+          "type": "color",
+          "value": "{global.layout.page.space.small}"
+        }
+      },
+      "width": {
+        "min": {
+          "description": "",
+          "type": "color",
+          "value": "{global.layout.page.width.min}"
+        },
+        "max": {
+          "description": "",
+          "type": "color",
+          "value": "{global.layout.page.width.max}"
+        }
+      }
+    }
+  },
+  "global": {
+    "typography": {
       "font-family": {
-        "pp-mori": {
+        "inter": {
           "description": "",
           "type": "string",
-          "value": "{primitives.font.family.pp-mori}"
+          "value": "{primitives.font.family.inter}"
         },
         "lyon-display": {
           "description": "",
           "type": "string",
           "value": "{primitives.font.family.lyon-display}"
         },
-        "inter": {
+        "pp-mori": {
           "description": "",
           "type": "string",
-          "value": "{primitives.font.family.inter}"
+          "value": "{primitives.font.family.pp-mori}"
         }
       },
       "size": {
@@ -2695,3699 +5910,585 @@
           "value": "{primitives.font.line-height.80}"
         }
       },
-      "color": {
-        "midtone": {
-          "description": "",
-          "type": "color",
-          "value": "{semantics.color.identity.base.aubergine-750}"
-        },
-        "darkest": {
-          "description": "",
-          "type": "color",
-          "value": "{primitives.color.aubergine.850}"
-        },
-        "lightest": {
-          "description": "",
-          "type": "color",
-          "value": "{semantics.color.identity.brand.carmine-525}"
-        }
-      },
-      "space": {
+      "weight": {
         "medium": {
           "description": "",
-          "type": "color",
-          "value": "{semantics.layout.element.space.medium}"
+          "type": "dimension",
+          "value": "{primitives.font.weight.500}"
         },
-        "large": {
+        "regular": {
           "description": "",
-          "type": "color",
-          "value": "{semantics.layout.element.space.large}"
+          "type": "dimension",
+          "value": "{primitives.font.weight.400}"
         },
-        "small": {
+        "book": {
           "description": "",
-          "type": "color",
-          "value": "{semantics.layout.element.space.xsmall}"
+          "type": "dimension",
+          "value": "{primitives.font.weight.300}"
+        },
+        "semi-bold": {
+          "description": "",
+          "type": "dimension",
+          "value": "{primitives.font.weight.600}"
+        },
+        "light": {
+          "description": "",
+          "type": "dimension",
+          "value": "{primitives.font.weight.200}"
         }
-      }
-    },
-    "structural": {
-      "radius": {
-        "description": "",
-        "type": "color",
-        "value": "{semantics.layout.element.radius.pill}"
-      },
-      "stroke": {
-        "description": "",
-        "type": "color",
-        "value": "{semantics.layout.element.stroke.regular}"
-      },
-      "space": {
-        "description": "",
-        "type": "color",
-        "value": "{semantics.layout.element.space.tiny}"
       },
       "color": {
-        "brightest": {
+        "dark": {
           "description": "",
           "type": "color",
-          "value": "{primitives.color.wine.150}"
-        },
-        "darkest": {
-          "description": "",
-          "type": "color",
-          "value": "{primitives.color.wine.750}"
-        }
-      }
-    },
-    "data-display": {
-      "color": {
-        "brightest": {
-          "description": "",
-          "type": "color",
-          "value": "{semantics.color.identity.base.aubergine-25}"
+          "value": "{global.color.identity.base.aubergine-750}"
         },
         "midtone": {
           "description": "",
           "type": "color",
-          "value": "{semantics.color.identity.base.aubergine-50}"
+          "value": "{global.color.identity.extended.wine-600}"
         },
         "bright": {
           "description": "",
           "type": "color",
-          "value": "{semantics.color.identity.extended.wine-50}"
-        },
-        "darker": {
-          "description": "",
-          "type": "color",
-          "value": "{semantics.color.identity.base.aubergine-850}"
+          "value": "{global.color.identity.extended.aubergine-525}"
         },
         "darkest": {
           "description": "",
           "type": "color",
-          "value": "{semantics.color.identity.base.aubergine-900}"
-        },
-        "dark": {
-          "description": "",
-          "type": "color",
-          "value": "{semantics.color.identity.extended.wine-150}"
+          "value": "{global.color.identity.base.aubergine-850}"
         },
         "brand": {
           "description": "",
           "type": "color",
-          "value": "{semantics.color.identity.brand.carmine-525}"
+          "value": "{global.color.identity.brand.carmine-525}"
         }
       },
-      "stroke": {
-        "description": "",
-        "type": "color",
-        "value": "{semantics.layout.element.stroke.regular}"
-      },
-      "radius": {
-        "description": "",
-        "type": "color",
-        "value": "{semantics.layout.element.radius.xsmall}"
-      },
-      "size": {
-        "description": "",
-        "type": "color",
-        "value": "{semantics.layout.element.size.xlarge}"
-      },
       "space": {
-        "small": {
-          "description": "",
-          "type": "color",
-          "value": "{semantics.layout.element.space.xsmall}"
-        },
-        "medium": {
-          "description": "",
-          "type": "color",
-          "value": "{semantics.layout.element.space.medium}"
-        },
-        "xlarge": {
-          "description": "",
-          "type": "color",
-          "value": "{semantics.layout.element.space.xxlarge}"
-        },
-        "tiny": {
-          "description": "",
-          "type": "color",
-          "value": "{semantics.layout.element.space.tiny}"
-        }
-      }
-    },
-    "navigation": {
-      "space": {
-        "small": {
-          "description": "",
-          "type": "color",
-          "value": "{semantics.layout.element.space.xsmall}"
-        },
-        "xxlarge": {
-          "description": "",
-          "type": "color",
-          "value": "{semantics.layout.element.space.xxxlarge}"
-        },
-        "medium": {
-          "description": "",
-          "type": "color",
-          "value": "{semantics.layout.element.space.medium}"
-        },
         "large": {
           "description": "",
           "type": "color",
-          "value": "{semantics.layout.element.space.large}"
-        },
-        "xlarge": {
-          "description": "",
-          "type": "color",
-          "value": "{semantics.layout.element.space.xxlarge}"
-        }
-      },
-      "color": {
-        "darkest": {
-          "description": "",
-          "type": "color",
-          "value": "{semantics.color.identity.base.aubergine-1000}"
-        },
-        "dark": {
-          "description": "",
-          "type": "color",
-          "value": "{semantics.color.identity.base.aubergine-850}"
-        },
-        "brightest": {
-          "description": "",
-          "type": "color",
-          "value": "{semantics.color.identity.base.aubergine-25}"
-        },
-        "bright": {
-          "description": "",
-          "type": "color",
-          "value": "{semantics.color.identity.extended.wine-525}"
-        }
-      },
-      "stroke": {
-        "description": "",
-        "type": "color",
-        "value": "{semantics.layout.element.stroke.regular}"
-      }
-    },
-    "feedback": {
-      "space": {
-        "small": {
-          "description": "",
-          "type": "color",
-          "value": "{semantics.layout.element.space.xsmall}"
+          "value": "{regional.layout.element.space.large}"
         },
         "medium": {
           "description": "",
           "type": "color",
-          "value": "{semantics.layout.element.space.small}"
+          "value": "{regional.layout.element.space.medium}"
         },
-        "large": {
-          "description": "",
-          "type": "color",
-          "value": "{semantics.layout.element.space.medium}"
-        },
-        "xsmall": {
-          "description": "",
-          "type": "color",
-          "value": "{semantics.layout.element.space.xxsmall}"
-        },
-        "xlarge": {
-          "description": "",
-          "type": "color",
-          "value": "{semantics.layout.element.space.large}"
-        }
-      },
-      "radius": {
         "small": {
           "description": "",
           "type": "color",
-          "value": "{semantics.layout.element.radius.xsmall}"
-        },
-        "medium": {
-          "description": "",
-          "type": "color",
-          "value": "{semantics.layout.element.radius.small}"
-        }
-      },
-      "color": {
-        "success": {
-          "darkest": {
-            "description": "",
-            "type": "color",
-            "value": "{semantics.color.ui.success.success-700}"
-          },
-          "brightest": {
-            "description": "",
-            "type": "color",
-            "value": "{semantics.color.ui.success.success-75}"
-          }
-        },
-        "info": {
-          "brightest": {
-            "description": "",
-            "type": "color",
-            "value": "{semantics.color.ui.informative.informative-25}"
-          },
-          "darkest": {
-            "description": "",
-            "type": "color",
-            "value": "{semantics.color.ui.informative.informative-700}"
-          }
-        },
-        "warning": {
-          "brightest": {
-            "description": "",
-            "type": "color",
-            "value": "{semantics.color.ui.warning.warning-75}"
-          },
-          "darkest": {
-            "description": "",
-            "type": "color",
-            "value": "{semantics.color.ui.warning.warning-700}"
-          }
-        }
-      }
-    }
-  },
-  "component": {
-    "button": {
-      "background": {
-        "color": {
-          "carmine": {
-            "main": {
-              "primary": {
-                "fallback": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.carmine.opaque.darkest}"
-                },
-                "hover": {
-                  "description": "primitive.carmine.1000 med 10% opacity.",
-                  "type": "color",
-                  "value": "{semantics.action.color.carmine.transparent.dark}"
-                }
-              }
-            },
-            "supplemental": {
-              "primary": {
-                "fallback": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.carmine.opaque.brightest}"
-                },
-                "hover": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.aubergine.transparent.midtone}"
-                }
-              }
-            }
-          },
-          "aubergine": {
-            "main": {
-              "primary": {
-                "fallback": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.aubergine.opaque.bright}"
-                },
-                "hover": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.aubergine.transparent.darkest}"
-                }
-              }
-            },
-            "supplemental": {
-              "primary": {
-                "fallback": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.aubergine.opaque.darkest}"
-                },
-                "hover": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.aubergine.transparent.brightest}"
-                }
-              }
-            },
-            "supplemental alt": {
-              "primary": {
-                "fallback": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.aubergine.opaque.brightest}"
-                },
-                "hover": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.aubergine.transparent.darkest}"
-                }
-              }
-            }
-          },
-          "neutral": {
-            "main": {
-              "primary": {
-                "fallback": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.neutral.opaque.bright}"
-                },
-                "hover": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.neutral.transparent.darkest}"
-                }
-              }
-            },
-            "supplemental": {
-              "primary": {
-                "fallback": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.neutral.opaque.darkest}"
-                },
-                "hover": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.neutral.transparent.brightest}"
-                }
-              }
-            },
-            "supplemental alt": {
-              "primary": {
-                "fallback": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.neutral.opaque.dark}"
-                },
-                "hover": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.neutral.transparent.darkest}"
-                }
-              }
-            }
-          },
-          "rettsdata": {
-            "main": {
-              "primary": {
-                "fallback": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.rettsdata.opaque.midtone}"
-                },
-                "hover": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.rettsdata.transparent.darkest}"
-                }
-              }
-            },
-            "supplemental": {
-              "primary": {
-                "fallback": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.rettsdata.opaque.brightest}"
-                },
-                "hover": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.rettsdata.transparent.darkest}"
-                }
-              }
-            },
-            "supplemental alt": {
-              "primary": {
-                "fallback": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.rettsdata.opaque.darkest}"
-                },
-                "hover": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.rettsdata.transparent.brightest}"
-                }
-              }
-            }
-          },
-          "success": {
-            "main": {
-              "primary": {
-                "fallback": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.success.opaque.brightest}"
-                },
-                "hover": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.success.transparent.darkest}"
-                }
-              }
-            },
-            "supplemental": {
-              "primary": {
-                "fallback": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.success.opaque.darkest}"
-                },
-                "hover": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.success.transparent.brightest}"
-                }
-              }
-            }
-          },
-          "informative": {
-            "main": {
-              "primary": {
-                "fallback": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.informative.opaque.brightest}"
-                },
-                "hover": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.informative.transparent.darkest}"
-                }
-              }
-            },
-            "supplemental": {
-              "primary": {
-                "fallback": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.informative.opaque.darkest}"
-                },
-                "hover": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.informative.transparent.brightest}"
-                }
-              }
-            }
-          },
-          "warning": {
-            "main": {
-              "primary": {
-                "fallback": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.warning.opaque.brightest}"
-                },
-                "hover": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.warning.transparent.darkest}"
-                }
-              }
-            },
-            "supplemental": {
-              "primary": {
-                "fallback": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.warning.opaque.darkest}"
-                },
-                "hover": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.warning.transparent.brightest}"
-                }
-              }
-            }
-          },
-          "nostalgia": {
-            "main": {
-              "primary": {
-                "fallback": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.nostalgia.opaque.darkest}"
-                },
-                "hover": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.nostalgia.transparent.brightest}"
-                }
-              }
-            },
-            "supplemental": {
-              "primary": {
-                "fallback": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.nostalgia.opaque.brightest}"
-                },
-                "hover": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.nostalgia.transparent.darkest}"
-                }
-              }
-            }
-          },
-          "nature": {
-            "main": {
-              "primary": {
-                "fallback": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.nature.opaque.darkest}"
-                },
-                "hover": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.nature.transparent.brightest}"
-                }
-              }
-            },
-            "supplemental": {
-              "primary": {
-                "fallback": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.nature.opaque.brightest}"
-                },
-                "hover": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.nature.transparent.darkest}"
-                }
-              }
-            }
-          },
-          "romance": {
-            "main": {
-              "primary": {
-                "fallback": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.romance.opaque.darkest}"
-                },
-                "hover": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.romance.transparent.brightest}"
-                }
-              }
-            },
-            "supplemental": {
-              "primary": {
-                "fallback": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.romance.opaque.brightest}"
-                },
-                "hover": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.romance.transparent.darkest}"
-                }
-              }
-            }
-          },
-          "vacation": {
-            "main": {
-              "primary": {
-                "fallback": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.vacation.opaque.darkest}"
-                },
-                "hover": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.vacation.transparent.brightest}"
-                }
-              }
-            },
-            "supplemental": {
-              "primary": {
-                "fallback": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.vacation.opaque.brightest}"
-                },
-                "hover": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.vacation.transparent.darkest}"
-                }
-              }
-            }
-          },
-          "fantasy": {
-            "main": {
-              "primary": {
-                "fallback": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.fantasy.opaque.darkest}"
-                },
-                "hover": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.fantasy.transparent.brightest}"
-                }
-              }
-            },
-            "supplemental": {
-              "primary": {
-                "fallback": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.fantasy.opaque.brightest}"
-                },
-                "hover": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.fantasy.transparent.darkest}"
-                }
-              }
-            }
-          },
-          "thriller": {
-            "main": {
-              "primary": {
-                "fallback": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.thriller.opaque.darkest}"
-                },
-                "hover": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.thriller.transparent.brightest}"
-                }
-              }
-            },
-            "supplemental": {
-              "primary": {
-                "fallback": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.thriller.opaque.brightest}"
-                },
-                "hover": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.thriller.transparent.darkest}"
-                }
-              }
-            }
-          }
-        }
-      },
-      "container": {
-        "size": {
-          "height": {
-            "description": "",
-            "type": "color",
-            "value": "{semantics.action.size.xlarge}"
-          }
-        },
-        "border": {
-          "radius": {
-            "description": "",
-            "type": "color",
-            "value": "{semantics.action.radius.xxsmall}"
-          },
-          "width": {
-            "hover": {
-              "description": "",
-              "type": "color",
-              "value": "{semantics.layout.element.stroke.regular}"
-            },
-            "active": {
-              "description": "",
-              "type": "color",
-              "value": "{semantics.layout.element.stroke.regular}"
-            }
-          },
-          "color": {
-            "aubergine": {
-              "main": {
-                "secondary": {
-                  "hover": {
-                    "description": "",
-                    "type": "color",
-                    "value": "{semantics.action.color.aubergine.opaque.dark}"
-                  },
-                  "active": {
-                    "description": "",
-                    "type": "color",
-                    "value": "{semantics.action.color.aubergine.opaque.dark}"
-                  }
-                }
-              },
-              "supplemental": {
-                "secondary": {
-                  "hover": {
-                    "description": "",
-                    "type": "color",
-                    "value": "{semantics.action.color.aubergine.opaque.brightest}"
-                  },
-                  "active": {
-                    "description": "",
-                    "type": "color",
-                    "value": "{semantics.action.color.aubergine.opaque.brightest}"
-                  }
-                }
-              }
-            },
-            "carmine": {
-              "main": {
-                "secondary": {
-                  "hover": {
-                    "description": "",
-                    "type": "color",
-                    "value": "{semantics.action.color.carmine.opaque.darkest}"
-                  },
-                  "active": {
-                    "description": "",
-                    "type": "color",
-                    "value": "{semantics.action.color.carmine.opaque.darkest}"
-                  }
-                }
-              },
-              "supplemental": {
-                "secondary": {
-                  "hover": {
-                    "description": "",
-                    "type": "color",
-                    "value": "{semantics.action.color.carmine.opaque.brightest}"
-                  },
-                  "active": {
-                    "description": "",
-                    "type": "color",
-                    "value": "{semantics.action.color.carmine.opaque.brightest}"
-                  }
-                }
-              }
-            },
-            "rettsdata": {
-              "main": {
-                "secondary": {
-                  "hover": {
-                    "description": "",
-                    "type": "color",
-                    "value": "{semantics.action.color.rettsdata.opaque.midtone}"
-                  },
-                  "active": {
-                    "description": "",
-                    "type": "color",
-                    "value": "{semantics.action.color.rettsdata.opaque.midtone}"
-                  }
-                }
-              },
-              "supplemental": {
-                "secondary": {
-                  "hover": {
-                    "description": "",
-                    "type": "color",
-                    "value": "{semantics.action.color.rettsdata.opaque.brightest}"
-                  },
-                  "active": {
-                    "description": "",
-                    "type": "color",
-                    "value": "{semantics.action.color.rettsdata.opaque.brightest}"
-                  }
-                }
-              }
-            },
-            "neutral": {
-              "main": {
-                "secondary": {
-                  "hover": {
-                    "description": "",
-                    "type": "color",
-                    "value": "{semantics.action.color.neutral.opaque.darkest}"
-                  },
-                  "active": {
-                    "description": "",
-                    "type": "color",
-                    "value": "{semantics.action.color.neutral.opaque.darkest}"
-                  }
-                }
-              },
-              "supplemental": {
-                "secondary": {
-                  "hover": {
-                    "description": "",
-                    "type": "color",
-                    "value": "{semantics.action.color.neutral.opaque.brightest}"
-                  },
-                  "active": {
-                    "description": "",
-                    "type": "color",
-                    "value": "{semantics.action.color.neutral.opaque.brightest}"
-                  }
-                }
-              }
-            },
-            "nostalgia": {
-              "main": {
-                "secondary": {
-                  "hover": {
-                    "description": "",
-                    "type": "color",
-                    "value": "{semantics.action.color.nostalgia.opaque.darkest}"
-                  },
-                  "active": {
-                    "description": "",
-                    "type": "color",
-                    "value": "{semantics.action.color.nostalgia.opaque.darkest}"
-                  }
-                }
-              },
-              "supplemental": {
-                "secondary": {
-                  "hover": {
-                    "description": "",
-                    "type": "color",
-                    "value": "{semantics.action.color.nostalgia.opaque.brightest}"
-                  },
-                  "active": {
-                    "description": "",
-                    "type": "color",
-                    "value": "{semantics.action.color.nostalgia.opaque.brightest}"
-                  }
-                }
-              }
-            },
-            "nature": {
-              "main": {
-                "secondary": {
-                  "hover": {
-                    "description": "",
-                    "type": "color",
-                    "value": "{semantics.action.color.nature.opaque.darkest}"
-                  },
-                  "active": {
-                    "description": "",
-                    "type": "color",
-                    "value": "{semantics.action.color.nature.opaque.darkest}"
-                  }
-                }
-              },
-              "supplemental": {
-                "secondary": {
-                  "hover": {
-                    "description": "",
-                    "type": "color",
-                    "value": "{semantics.action.color.nature.opaque.brightest}"
-                  },
-                  "active": {
-                    "description": "",
-                    "type": "color",
-                    "value": "{semantics.action.color.nature.opaque.brightest}"
-                  }
-                }
-              }
-            },
-            "romance": {
-              "main": {
-                "secondary": {
-                  "hover": {
-                    "description": "",
-                    "type": "color",
-                    "value": "{semantics.action.color.romance.opaque.darkest}"
-                  },
-                  "active": {
-                    "description": "",
-                    "type": "color",
-                    "value": "{semantics.action.color.romance.opaque.darkest}"
-                  }
-                }
-              },
-              "supplemental": {
-                "secondary": {
-                  "hover": {
-                    "description": "",
-                    "type": "color",
-                    "value": "{semantics.action.color.romance.opaque.brightest}"
-                  },
-                  "active": {
-                    "description": "",
-                    "type": "color",
-                    "value": "{semantics.action.color.romance.opaque.brightest}"
-                  }
-                }
-              }
-            },
-            "vacation": {
-              "main": {
-                "secondary": {
-                  "hover": {
-                    "description": "",
-                    "type": "color",
-                    "value": "{semantics.action.color.vacation.opaque.darkest}"
-                  },
-                  "active": {
-                    "description": "",
-                    "type": "color",
-                    "value": "{semantics.action.color.vacation.opaque.darkest}"
-                  }
-                }
-              },
-              "supplemental": {
-                "secondary": {
-                  "hover": {
-                    "description": "",
-                    "type": "color",
-                    "value": "{semantics.action.color.vacation.opaque.brightest}"
-                  },
-                  "active": {
-                    "description": "",
-                    "type": "color",
-                    "value": "{semantics.action.color.vacation.opaque.brightest}"
-                  }
-                }
-              }
-            },
-            "fantasy": {
-              "main": {
-                "secondary": {
-                  "hover": {
-                    "description": "",
-                    "type": "color",
-                    "value": "{semantics.action.color.fantasy.opaque.darkest}"
-                  },
-                  "active": {
-                    "description": "",
-                    "type": "color",
-                    "value": "{semantics.action.color.fantasy.opaque.darkest}"
-                  }
-                }
-              },
-              "supplemental": {
-                "secondary": {
-                  "hover": {
-                    "description": "",
-                    "type": "color",
-                    "value": "{semantics.action.color.fantasy.opaque.brightest}"
-                  },
-                  "active": {
-                    "description": "",
-                    "type": "color",
-                    "value": "{semantics.action.color.fantasy.opaque.brightest}"
-                  }
-                }
-              }
-            },
-            "thriller": {
-              "main": {
-                "secondary": {
-                  "hover": {
-                    "description": "",
-                    "type": "color",
-                    "value": "{semantics.action.color.thriller.opaque.darkest}"
-                  },
-                  "active": {
-                    "description": "",
-                    "type": "color",
-                    "value": "{semantics.action.color.thriller.opaque.darkest}"
-                  }
-                }
-              },
-              "supplemental": {
-                "secondary": {
-                  "fallback": {
-                    "description": "",
-                    "type": "color",
-                    "value": "{semantics.action.color.thriller.opaque.brightest}"
-                  },
-                  "active": {
-                    "description": "",
-                    "type": "color",
-                    "value": "{semantics.action.color.thriller.opaque.brightest}"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "gap": {
-          "description": "",
-          "type": "color",
-          "value": "{semantics.layout.element.space.xsmall}"
-        },
-        "padding": {
-          "block": {
-            "description": "",
-            "type": "color",
-            "value": "{semantics.action.space.small}",
-            "icon-only": {
-              "description": "",
-              "type": "color",
-              "value": "{semantics.action.space.medium}"
-            }
-          },
-          "inline": {
-            "description": "",
-            "type": "color",
-            "value": "{semantics.action.space.large}",
-            "icon-only": {
-              "description": "",
-              "type": "color",
-              "value": "{semantics.action.space.medium}"
-            }
-          }
-        }
-      },
-      "text": {
-        "color": {
-          "carmine": {
-            "main": {
-              "primary": {
-                "fallback": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.carmine.opaque.brightest}"
-                }
-              },
-              "secondary": {
-                "fallback": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.carmine.opaque.darkest}"
-                }
-              }
-            },
-            "supplemental": {
-              "primary": {
-                "fallback": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.carmine.opaque.darkest}"
-                }
-              },
-              "secondary": {
-                "fallback": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.carmine.opaque.brightest}"
-                }
-              }
-            }
-          },
-          "aubergine": {
-            "main": {
-              "primary": {
-                "fallback": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.aubergine.opaque.dark}"
-                }
-              },
-              "secondary": {
-                "fallback": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.aubergine.opaque.dark}"
-                }
-              }
-            },
-            "supplemental": {
-              "primary": {
-                "fallback": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.aubergine.opaque.bright}"
-                }
-              },
-              "secondary": {
-                "fallback": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.aubergine.opaque.bright}"
-                }
-              }
-            },
-            "supplemental alt": {
-              "primary": {
-                "fallback": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.aubergine.opaque.darkest}"
-                }
-              }
-            }
-          },
-          "neutral": {
-            "main": {
-              "primary": {
-                "fallback": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.neutral.opaque.darkest}"
-                }
-              },
-              "secondary": {
-                "fallback": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.neutral.opaque.darkest}"
-                }
-              }
-            },
-            "supplemental": {
-              "primary": {
-                "fallback": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.neutral.opaque.bright}"
-                }
-              },
-              "secondary": {
-                "fallback": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.neutral.opaque.bright}"
-                }
-              }
-            },
-            "supplemental alt": {
-              "primary": {
-                "fallback": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.neutral.opaque.brightest}"
-                }
-              }
-            }
-          },
-          "rettsdata": {
-            "main": {
-              "primary": {
-                "fallback": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.rettsdata.opaque.brightest}"
-                }
-              },
-              "secondary": {
-                "fallback": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.rettsdata.opaque.midtone}"
-                }
-              }
-            },
-            "supplemental": {
-              "primary": {
-                "fallback": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.rettsdata.opaque.midtone}"
-                }
-              },
-              "secondary": {
-                "fallback": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.rettsdata.opaque.brightest}"
-                }
-              }
-            },
-            "supplemental alt": {
-              "primary": {
-                "fallback": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.rettsdata.opaque.brightest}"
-                }
-              }
-            }
-          },
-          "success": {
-            "main": {
-              "primary": {
-                "fallback": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.success.opaque.darkest}"
-                }
-              }
-            },
-            "supplemental": {
-              "primary": {
-                "fallback": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.success.opaque.brightest}"
-                }
-              }
-            }
-          },
-          "informative": {
-            "main": {
-              "primary": {
-                "fallback": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.informative.opaque.darkest}"
-                }
-              }
-            },
-            "supplemental": {
-              "primary": {
-                "fallback": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.informative.opaque.brightest}"
-                }
-              }
-            }
-          },
-          "warning": {
-            "main": {
-              "primary": {
-                "fallback": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.warning.opaque.darkest}"
-                }
-              }
-            },
-            "supplemental": {
-              "primary": {
-                "fallback": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.warning.opaque.brightest}"
-                }
-              }
-            }
-          },
-          "nostalgia": {
-            "main": {
-              "primary": {
-                "fallback": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.nostalgia.opaque.brightest}"
-                }
-              },
-              "secondary": {
-                "fallback": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.nostalgia.opaque.darkest}"
-                }
-              }
-            },
-            "supplemental": {
-              "primary": {
-                "fallback": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.nostalgia.opaque.darkest}"
-                }
-              },
-              "secondary": {
-                "fallback": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.nostalgia.opaque.brightest}"
-                }
-              }
-            }
-          },
-          "nature": {
-            "main": {
-              "primary": {
-                "fallback": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.nature.opaque.brightest}"
-                }
-              },
-              "secondary": {
-                "fallback": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.nature.opaque.darkest}"
-                }
-              }
-            },
-            "supplemental": {
-              "primary": {
-                "fallback": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.nature.opaque.darkest}"
-                }
-              },
-              "secondary": {
-                "fallback": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.nature.opaque.brightest}"
-                }
-              }
-            }
-          },
-          "romance": {
-            "main": {
-              "primary": {
-                "fallback": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.romance.opaque.brightest}"
-                }
-              },
-              "secondary": {
-                "fallback": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.romance.opaque.darkest}"
-                }
-              }
-            },
-            "supplemental": {
-              "primary": {
-                "fallback": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.romance.opaque.darkest}"
-                }
-              },
-              "secondary": {
-                "fallback": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.romance.opaque.brightest}"
-                }
-              }
-            }
-          },
-          "vacation": {
-            "main": {
-              "primary": {
-                "fallback": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.vacation.opaque.brightest}"
-                }
-              },
-              "secondary": {
-                "fallback": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.vacation.opaque.darkest}"
-                }
-              }
-            },
-            "supplemental": {
-              "primary": {
-                "fallback": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.vacation.opaque.darkest}"
-                }
-              },
-              "secondary": {
-                "fallback": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.vacation.opaque.brightest}"
-                }
-              }
-            }
-          },
-          "fantasy": {
-            "main": {
-              "primary": {
-                "fallback": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.fantasy.opaque.brightest}"
-                }
-              },
-              "secondary": {
-                "fallback": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.fantasy.opaque.darkest}"
-                }
-              }
-            },
-            "supplemental": {
-              "primary": {
-                "fallback": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.fantasy.opaque.darkest}"
-                }
-              },
-              "secondary": {
-                "fallback": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.fantasy.opaque.brightest}"
-                }
-              }
-            }
-          },
-          "thriller": {
-            "main": {
-              "primary": {
-                "fallback": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.thriller.opaque.brightest}"
-                }
-              },
-              "secondary": {
-                "fallback": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.thriller.opaque.darkest}"
-                }
-              }
-            },
-            "supplemental": {
-              "primary": {
-                "fallback": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.thriller.opaque.darkest}"
-                }
-              },
-              "secondary": {
-                "fallback": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.thriller.opaque.brightest}"
-                }
-              }
-            }
-          }
-        }
-      },
-      "icon": {
-        "size": {
-          "width": {
-            "small": {
-              "description": "",
-              "type": "color",
-              "value": "{semantics.action.visual.icon.small}"
-            },
-            "regular": {
-              "description": "",
-              "type": "color",
-              "value": "{semantics.action.visual.icon.regular}"
-            }
-          },
-          "height": {
-            "small": {
-              "description": "",
-              "type": "color",
-              "value": "{semantics.visual.icon.size.small}"
-            },
-            "regular": {
-              "description": "",
-              "type": "color",
-              "value": "{semantics.visual.icon.size.medium}"
-            }
-          }
-        },
-        "color": {
-          "carmine": {
-            "main": {
-              "primary": {
-                "fallback": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.carmine.opaque.brightest}"
-                }
-              },
-              "secondary": {
-                "fallback": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.carmine.opaque.darkest}"
-                }
-              }
-            },
-            "supplemental": {
-              "primary": {
-                "fallback": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.carmine.opaque.darkest}"
-                }
-              },
-              "secondary": {
-                "fallback": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.carmine.opaque.brightest}"
-                }
-              }
-            }
-          },
-          "aubergine": {
-            "main": {
-              "primary": {
-                "fallback": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.aubergine.opaque.dark}"
-                }
-              },
-              "secondary": {
-                "fallback": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.aubergine.opaque.dark}"
-                }
-              }
-            },
-            "supplemental": {
-              "primary": {
-                "fallback": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.aubergine.opaque.bright}"
-                }
-              },
-              "secondary": {
-                "fallback": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.aubergine.opaque.bright}"
-                }
-              }
-            },
-            "supplemental alt": {
-              "primary": {
-                "fallback": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.aubergine.opaque.darkest}"
-                }
-              }
-            }
-          },
-          "rettsdata": {
-            "main": {
-              "primary": {
-                "fallback": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.rettsdata.opaque.brightest}"
-                }
-              },
-              "secondary": {
-                "fallback": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.rettsdata.opaque.midtone}"
-                }
-              }
-            },
-            "supplemental": {
-              "primary": {
-                "fallback": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.rettsdata.opaque.midtone}"
-                }
-              },
-              "secondary": {
-                "fallback": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.rettsdata.opaque.brightest}"
-                }
-              }
-            },
-            "supplemental alt": {
-              "primary": {
-                "fallback": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.rettsdata.opaque.brightest}"
-                }
-              }
-            }
-          },
-          "neutral": {
-            "main": {
-              "primary": {
-                "fallback": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.neutral.opaque.darkest}"
-                }
-              },
-              "secondary": {
-                "fallback": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.neutral.opaque.darkest}"
-                }
-              }
-            },
-            "supplemental": {
-              "primary": {
-                "fallback": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.neutral.opaque.bright}"
-                }
-              },
-              "secondary": {
-                "fallback": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.neutral.opaque.bright}"
-                }
-              }
-            },
-            "supplemental alt": {
-              "primary": {
-                "fallback": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.neutral.opaque.brightest}"
-                }
-              }
-            }
-          },
-          "success": {
-            "main": {
-              "primary": {
-                "fallback": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.success.opaque.darkest}"
-                }
-              }
-            },
-            "supplemental": {
-              "primary": {
-                "fallback": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.success.opaque.brightest}"
-                }
-              }
-            }
-          },
-          "informative": {
-            "main": {
-              "primary": {
-                "fallback": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.informative.opaque.darkest}"
-                }
-              }
-            },
-            "supplemental": {
-              "primary": {
-                "fallback": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.informative.opaque.brightest}"
-                }
-              }
-            }
-          },
-          "warning": {
-            "main": {
-              "primary": {
-                "fallback": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.warning.opaque.darkest}"
-                }
-              }
-            },
-            "supplemental": {
-              "primary": {
-                "fallback": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.warning.opaque.brightest}"
-                }
-              }
-            }
-          },
-          "nostalgia": {
-            "main": {
-              "primary": {
-                "fallback": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.nostalgia.opaque.brightest}"
-                }
-              },
-              "secondary": {
-                "fallback": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.nostalgia.opaque.darkest}"
-                }
-              }
-            },
-            "supplemental": {
-              "primary": {
-                "fallback": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.nostalgia.opaque.darkest}"
-                }
-              },
-              "secondary": {
-                "fallback": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.nostalgia.opaque.brightest}"
-                }
-              }
-            }
-          },
-          "nature": {
-            "main": {
-              "primary": {
-                "fallback": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.nature.opaque.brightest}"
-                }
-              },
-              "secondary": {
-                "fallback": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.nature.opaque.darkest}"
-                }
-              }
-            },
-            "supplemental": {
-              "primary": {
-                "fallback": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.nature.opaque.darkest}"
-                }
-              },
-              "secondary": {
-                "fallback": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.nature.opaque.brightest}"
-                }
-              }
-            }
-          },
-          "romance": {
-            "main": {
-              "primary": {
-                "fallback": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.romance.opaque.brightest}"
-                }
-              },
-              "secondary": {
-                "fallback": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.romance.opaque.darkest}"
-                }
-              }
-            },
-            "supplemental": {
-              "primary": {
-                "fallback": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.romance.opaque.darkest}"
-                }
-              },
-              "secondary": {
-                "fallback": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.romance.opaque.brightest}"
-                }
-              }
-            }
-          },
-          "thriller": {
-            "main": {
-              "primary": {
-                "fallback": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.thriller.opaque.brightest}"
-                }
-              },
-              "secondary": {
-                "fallback": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.thriller.opaque.darkest}"
-                }
-              }
-            },
-            "supplemental": {
-              "primary": {
-                "fallback": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.thriller.opaque.darkest}"
-                }
-              },
-              "secondary": {
-                "fallback": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.thriller.opaque.brightest}"
-                }
-              }
-            }
-          },
-          "fantasy": {
-            "main": {
-              "primary": {
-                "fallback": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.fantasy.opaque.brightest}"
-                }
-              },
-              "secondary": {
-                "fallback": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.fantasy.opaque.darkest}"
-                }
-              }
-            },
-            "supplemental": {
-              "primary": {
-                "fallback": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.fantasy.opaque.darkest}"
-                }
-              },
-              "secondary": {
-                "fallback": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.fantasy.opaque.brightest}"
-                }
-              }
-            }
-          },
-          "vacation": {
-            "main": {
-              "primary": {
-                "fallback": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.vacation.opaque.brightest}"
-                }
-              },
-              "secondary": {
-                "fallback": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.vacation.opaque.darkest}"
-                }
-              }
-            },
-            "supplemental": {
-              "primary": {
-                "fallback": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.vacation.opaque.darkest}"
-                }
-              },
-              "secondary": {
-                "fallback": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.action.color.vacation.opaque.brightest}"
-                }
-              }
-            }
-          }
+          "value": "{regional.layout.element.space.xsmall}"
         }
       }
     },
-    "input": {
-      "textual": {
-        "label": {
-          "color": {
-            "main": {
-              "fallback": {
-                "description": "Textual means type text, password, search, email, tel, url",
-                "type": "color",
-                "value": "{semantics.form.color.base.midtone}"
-              },
-              "active": {
-                "description": "Textual means type text, password, search, email, tel, url",
-                "type": "color",
-                "value": "{semantics.form.color.base.darker}"
-              }
-            },
-            "supplement": {
-              "fallback": {
-                "description": "Textual means type text, password, search, email, tel, url",
-                "type": "color",
-                "value": "{semantics.form.color.base.bright}"
-              },
-              "active": {
-                "description": "Textual means type text, password, search, email, tel, url",
-                "type": "color",
-                "value": "{semantics.form.color.base.dark}"
-              }
-            }
+    "color": {
+      "identity": {
+        "brand": {
+          "carmine-525": {
+            "description": "",
+            "type": "color",
+            "value": "{primitives.color.carmine.525}"
           }
         },
-        "input-text": {
-          "color": {
-            "primary": {
-              "fallback": {
-                "description": "Textual means type text, password, search, email, tel, url",
-                "type": "color",
-                "value": "{semantics.form.color.base.darker}"
-              }
-            },
-            "secondary": {
-              "fallback": {
-                "description": "Textual means type text, password, search, email, tel, url",
-                "type": "color",
-                "value": "{semantics.form.color.base.bright}"
-              }
-            }
+        "base": {
+          "aubergine-25": {
+            "description": "",
+            "type": "color",
+            "value": "{primitives.color.aubergine.25}"
+          },
+          "aubergine-50": {
+            "description": "",
+            "type": "color",
+            "value": "{primitives.color.aubergine.50}"
+          },
+          "aubergine-675": {
+            "description": "",
+            "type": "color",
+            "value": "{primitives.color.aubergine.675}"
+          },
+          "aubergine-750": {
+            "description": "",
+            "type": "color",
+            "value": "{primitives.color.aubergine.750}"
+          },
+          "aubergine-850": {
+            "description": "",
+            "type": "color",
+            "value": "{primitives.color.aubergine.850}"
+          },
+          "aubergine-900": {
+            "description": "",
+            "type": "color",
+            "value": "{primitives.color.aubergine.900}"
+          },
+          "aubergine-150": {
+            "description": "",
+            "type": "color",
+            "value": "{primitives.color.aubergine.150}"
+          },
+          "aubergine-1000": {
+            "description": "",
+            "type": "color",
+            "value": "{primitives.color.aubergine.1000}"
           }
         },
-        "supportive-text": {
-          "color": {
-            "primary": {
-              "fallback": {
-                "description": "Textual means type text, password, search, email, tel, url",
-                "type": "color",
-                "value": "{semantics.form.color.base.darker}"
-              }
-            },
-            "secondary": {
-              "fallback": {
-                "description": "Textual means type text, password, search, email, tel, url",
-                "type": "color",
-                "value": "{semantics.form.color.base.bright}"
-              }
-            }
+        "extended": {
+          "carmine-25": {
+            "description": "",
+            "type": "color",
+            "value": "{primitives.color.carmine.25}"
+          },
+          "wine-525": {
+            "description": "",
+            "type": "color",
+            "value": "{primitives.color.wine.525}"
+          },
+          "wine-600": {
+            "description": "",
+            "type": "color",
+            "value": "{primitives.color.wine.600}"
+          },
+          "wine-50": {
+            "description": "",
+            "type": "color",
+            "value": "{primitives.color.wine.50}"
+          },
+          "wine-150": {
+            "description": "",
+            "type": "color",
+            "value": "{primitives.color.wine.150}"
+          },
+          "aubergine-425": {
+            "description": "",
+            "type": "color",
+            "value": "{primitives.color.aubergine.425}"
+          },
+          "aubergine-525": {
+            "description": "",
+            "type": "color",
+            "value": "{primitives.color.aubergine.525}"
           }
         },
-        "background": {
-          "color": {
-            "primary": {
-              "hover": {
-                "description": "",
-                "type": "color",
-                "value": "{semantics.form.color.base.brighter}"
-              },
-              "active": {
-                "description": "",
-                "type": "color",
-                "value": "{semantics.form.color.base.brighter}"
-              }
-            },
-            "secondary": {
-              "hover": {
-                "description": "",
-                "type": "color",
-                "value": "{semantics.form.color.base.darker}"
-              },
-              "active": {
-                "description": "",
-                "type": "color",
-                "value": "{semantics.form.color.base.darker}"
-              }
-            }
+        "neutral": {
+          "concrete-25": {
+            "description": "",
+            "type": "color",
+            "value": "{primitives.color.concrete.25}"
+          },
+          "concrete-50": {
+            "description": "",
+            "type": "color",
+            "value": "{primitives.color.concrete.50}"
+          },
+          "concrete-525": {
+            "description": "",
+            "type": "color",
+            "value": "{primitives.color.concrete.525}"
+          },
+          "concrete-900": {
+            "description": "",
+            "type": "color",
+            "value": "{primitives.color.concrete.900}"
           }
         },
-        "container": {
-          "border-bottom": {
-            "color": {
-              "supplemental": {
-                "fallback": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.form.color.base.dark}"
-                }
-              },
-              "main": {
-                "fallback": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.form.color.base.darker}"
-                }
-              }
-            },
-            "width": {
-              "fallback": {
-                "description": "",
-                "type": "color",
-                "value": "{semantics.form.stroke.regular}"
-              },
-              "active": {
-                "description": "",
-                "type": "color",
-                "value": "{semantics.form.stroke.thick}"
-              }
-            }
-          },
-          "padding": {
+        "rettsdata": {
+          "rettsdata-20": {
             "description": "",
             "type": "color",
-            "value": "{semantics.form.space.small}"
+            "value": "{primitives.color.lawblue.20}"
           },
-          "gap": {
+          "rettsdata-60": {
             "description": "",
             "type": "color",
-            "value": "{semantics.form.space.small}"
-          }
-        },
-        "icon": {
-          "color": {
-            "supplemental": {
-              "fallback": {
-                "description": "",
-                "type": "color",
-                "value": "{semantics.form.color.base.bright}"
-              }
-            },
-            "main": {
-              "fallback": {
-                "description": "",
-                "type": "color",
-                "value": "{semantics.form.color.base.darker}"
-              }
-            }
-          }
-        },
-        "wrapper": {
-          "gap": {
+            "value": "{primitives.color.lawblue.60}"
+          },
+          "rettsdata-90": {
             "description": "",
             "type": "color",
-            "value": "{semantics.form.space.xsmall}"
-          },
-          "padding": {
-            "description": "",
-            "type": "color",
-            "value": "{semantics.form.space.xsmall}"
-          }
-        },
-        "inner-container": {
-          "gap": {
-            "description": "",
-            "type": "color",
-            "value": "{semantics.action.space.xsmall}"
-          }
-        }
-      },
-      "selection": {
-        "label": {
-          "color": {
-            "fallback": {
-              "description": "",
-              "type": "color",
-              "value": "{semantics.form.color.base.darker}"
-            }
-          }
-        },
-        "radio-indicator": {
-          "outline": {
-            "radius": {
-              "description": "",
-              "type": "color",
-              "value": "{semantics.layout.element.radius.pill}"
-            },
-            "width": {
-              "description": "",
-              "type": "color",
-              "value": "{semantics.layout.element.stroke.fat}"
-            },
-            "color": {
-              "success": {
-                "hover": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.form.color.extended.brightest}"
-                },
-                "active": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.form.color.extended.midtone}"
-                }
-              },
-              "aubergine": {
-                "hover": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.form.color.base.brightest}"
-                },
-                "active": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.form.color.base.bright}"
-                }
-              }
-            }
-          },
-          "border": {
-            "radius": {
-              "description": "",
-              "type": "color",
-              "value": "{semantics.layout.element.radius.pill}"
-            },
-            "width": {
-              "description": "",
-              "type": "color",
-              "value": "{semantics.layout.element.stroke.regular}"
-            },
-            "color": {
-              "success": {
-                "fallback": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.form.color.extended.darkest}"
-                }
-              },
-              "aubergine": {
-                "fallback": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.form.color.base.darkest}"
-                }
-              }
-            }
-          },
-          "icon": {
-            "color": {
-              "success": {
-                "fallback": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.form.color.extended.darkest}"
-                }
-              },
-              "aubergine": {
-                "fallback": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.form.color.base.darkest}"
-                }
-              }
-            }
-          },
-          "container": {
-            "height": {
-              "description": "",
-              "type": "color",
-              "value": "{semantics.action.size.small}"
-            },
-            "width": {
-              "description": "",
-              "type": "color",
-              "value": "{semantics.action.size.small}"
-            }
-          }
-        },
-        "checkmark-indicator": {
-          "outline": {
-            "radius": {
-              "description": "",
-              "type": "color",
-              "value": "{semantics.layout.element.radius.xsmall}"
-            },
-            "width": {
-              "description": "",
-              "type": "color",
-              "value": "{semantics.layout.element.stroke.fat}"
-            },
-            "color": {
-              "success": {
-                "hover": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.form.color.extended.brightest}"
-                },
-                "active": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.form.color.extended.midtone}"
-                }
-              },
-              "aubergine": {
-                "hover": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.form.color.base.brightest}"
-                },
-                "active": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.form.color.base.bright}"
-                }
-              }
-            }
-          },
-          "border": {
-            "radius": {
-              "description": "",
-              "type": "color",
-              "value": "{semantics.layout.element.radius.large}"
-            },
-            "width": {
-              "description": "",
-              "type": "color",
-              "value": "{semantics.layout.element.stroke.regular}"
-            },
-            "color": {
-              "success": {
-                "idle": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.form.color.extended.darkest}"
-                },
-                "hover": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.form.color.extended.darkest}"
-                },
-                "active": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.form.color.extended.darkest}"
-                },
-                "focus": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.form.color.extended.darkest}"
-                }
-              },
-              "aubergine": {
-                "idle": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.form.color.base.darkest}"
-                },
-                "hover": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.form.color.base.darkest}"
-                },
-                "active": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.form.color.base.darkest}"
-                },
-                "focus": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.form.color.base.darkest}"
-                }
-              }
-            }
-          },
-          "icon": {
-            "color": {
-              "success": {
-                "fallback": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.form.color.extended.darkest}"
-                }
-              },
-              "aubergine": {
-                "fallback": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.form.color.base.darkest}"
-                }
-              }
-            }
-          },
-          "background": {
-            "color": {
-              "success": {
-                "idle": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.form.color.extended.brightest}"
-                },
-                "disabled": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.form.color.extended.midtone}"
-                }
-              },
-              "aubergine": {
-                "idle": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.form.color.base.brightest}"
-                },
-                "disabled": {
-                  "description": "",
-                  "type": "color",
-                  "value": "{semantics.form.color.base.bright}"
-                }
-              }
-            }
-          },
-          "container": {
-            "height": {
-              "description": "",
-              "type": "color",
-              "value": "{semantics.action.size.medium}"
-            },
-            "width": {
-              "description": "",
-              "type": "color",
-              "value": "{semantics.action.size.medium}"
-            }
-          }
-        },
-        "wrapper": {
-          "padding": {
-            "description": "",
-            "type": "color",
-            "value": "{semantics.form.space.xsmall}"
-          }
-        },
-        "container": {
-          "gap": {
-            "description": "",
-            "type": "color",
-            "value": "{semantics.form.space.medium}"
-          }
-        },
-        "inner-container-left": {
-          "gap": {
-            "description": "",
-            "type": "color",
-            "value": "{semantics.layout.element.space.small}"
-          }
-        }
-      }
-    },
-    "divider": {
-      "background": {
-        "color": {
-          "main": {
-            "description": "",
-            "type": "color",
-            "value": "{semantics.structural.color.brightest}"
-          },
-          "supplemental": {
-            "description": "",
-            "type": "color",
-            "value": "{semantics.structural.color.darkest}"
-          }
-        }
-      },
-      "container": {
-        "radius": {
-          "description": "",
-          "type": "color",
-          "value": "{semantics.structural.radius}"
-        },
-        "padding": {
-          "block": {
-            "horizontal": {
-              "description": "",
-              "type": "color",
-              "value": "{semantics.structural.space}"
-            }
-          },
-          "inline": {
-            "vertical": {
-              "description": "",
-              "type": "color",
-              "value": "{semantics.structural.space}"
-            }
-          }
-        },
-        "height": {
-          "horizontal": {
-            "description": "",
-            "type": "color",
-            "value": "{semantics.structural.stroke}"
-          }
-        },
-        "width": {
-          "vertical": {
-            "description": "",
-            "type": "color",
-            "value": "{semantics.structural.stroke}"
-          }
-        }
-      }
-    },
-    "wiki-list-item": {
-      "text": {
-        "color": {
-          "description": "",
-          "type": "color",
-          "value": "{semantics.data-display.color.darker}"
-        }
-      },
-      "container": {
-        "border": {
-          "radius": {
-            "description": "",
-            "type": "color",
-            "value": "{semantics.data-display.radius}"
-          }
-        },
-        "size": {
-          "height": {
-            "description": "",
-            "type": "color",
-            "value": "{semantics.data-display.size}"
-          }
-        },
-        "gap": {
-          "description": "",
-          "type": "color",
-          "value": "{semantics.data-display.space.small}"
-        },
-        "padding": {
-          "top": {
-            "description": "",
-            "type": "color",
-            "value": "{semantics.data-display.space.medium}"
-          },
-          "right": {
-            "description": "",
-            "type": "color",
-            "value": "{semantics.data-display.space.medium}"
-          },
-          "bottom": {
-            "description": "",
-            "type": "color",
-            "value": "{semantics.data-display.space.medium}"
-          },
-          "left": {
-            "description": "",
-            "type": "color",
-            "value": "{semantics.data-display.space.medium}",
-            "nested": {
-              "description": "",
-              "type": "color",
-              "value": "{semantics.data-display.space.xlarge}"
-            }
-          }
-        }
-      },
-      "background": {
-        "color": {
-          "hover": {
-            "description": "",
-            "type": "color",
-            "value": "{semantics.data-display.color.midtone}"
-          }
-        }
-      },
-      "border-bottom": {
-        "color": {
-          "active": {
-            "description": "",
-            "type": "color",
-            "value": "{semantics.data-display.color.darker}"
-          }
-        },
-        "width": {
-          "active": {
-            "description": "",
-            "type": "color",
-            "value": "{semantics.data-display.stroke}"
-          }
-        },
-        "padding": {
-          "top": {
-            "description": "",
-            "type": "color",
-            "value": "{semantics.data-display.space.tiny}"
-          }
-        }
-      },
-      "icon": {
-        "color": {
-          "description": "",
-          "type": "color",
-          "value": "{semantics.data-display.color.darker}"
-        }
-      }
-    },
-    "wiki-side-menu": {
-      "container": {
-        "padding": {
-          "description": "",
-          "type": "color",
-          "value": "{semantics.navigation.space.small}"
-        },
-        "gap": {
-          "description": "",
-          "type": "color",
-          "value": "{semantics.navigation.space.small}"
-        }
-      }
-    },
-    "wiki-navbar-item": {
-      "text": {
-        "color": {
-          "main": {
-            "description": "",
-            "type": "color",
-            "value": "{semantics.navigation.color.dark}"
-          },
-          "supplemental": {
-            "description": "",
-            "type": "color",
-            "value": "{semantics.navigation.color.brightest}"
-          }
-        }
-      },
-      "border-bottom": {
-        "width": {
-          "description": "",
-          "type": "color",
-          "value": "{semantics.navigation.stroke}"
-        },
-        "color": {
-          "main": {
-            "hover": {
-              "description": "",
-              "type": "color",
-              "value": "{semantics.navigation.color.dark}"
-            },
-            "active": {
-              "description": "",
-              "type": "color",
-              "value": "{semantics.navigation.color.dark}"
-            }
-          },
-          "supportive": {
-            "hover": {
-              "description": "",
-              "type": "color",
-              "value": "{semantics.navigation.color.brightest}"
-            },
-            "active": {
-              "description": "",
-              "type": "color",
-              "value": "{semantics.navigation.color.brightest}"
-            }
-          }
-        }
-      }
-    },
-    "wiki-navbar": {
-      "background": {
-        "color": {
-          "main": {
-            "description": "",
-            "type": "color",
-            "value": "{semantics.navigation.color.brightest}"
-          },
-          "supplemental": {
-            "description": "",
-            "type": "color",
-            "value": "{semantics.navigation.color.darkest}"
-          }
-        }
-      },
-      "text": {
-        "main": {
-          "description": "",
-          "type": "color",
-          "value": "{semantics.navigation.color.brightest}"
-        },
-        "supplemental": {
-          "description": "",
-          "type": "color",
-          "value": "{semantics.navigation.color.darkest}"
-        }
-      },
-      "container": {
-        "padding": {
-          "block": {
-            "description": "",
-            "type": "color",
-            "value": "{semantics.navigation.space.medium}"
-          }
-        },
-        "gap": {
-          "mobile": {
-            "description": "",
-            "type": "color",
-            "value": "{semantics.navigation.space.xxlarge}"
-          }
-        }
-      }
-    },
-    "article": {
-      "heading": {
-        "container": {
-          "padding": {
-            "bottom": {
-              "description": "",
-              "type": "color",
-              "value": "{semantics.typography.space.small}"
-            }
-          }
-        },
-        "text": {
-          "color": {
-            "h1": {
-              "base": {
-                "description": "",
-                "type": "color",
-                "value": "{semantics.typography.color.midtone}"
-              }
-            },
-            "highlight": {
-              "description": "",
-              "type": "color",
-              "value": "{semantics.typography.color.lightest}"
-            },
-            "h2": {
-              "base": {
-                "description": "",
-                "type": "color",
-                "value": "{semantics.typography.color.darkest}"
-              }
-            }
-          }
-        }
-      },
-      "ingress": {
-        "text": {
-          "color": {
-            "base": {
-              "description": "",
-              "type": "color",
-              "value": "{semantics.typography.color.darkest}"
-            },
-            "highlight": {
-              "description": "",
-              "type": "color",
-              "value": "{semantics.typography.color.lightest}"
-            }
-          }
-        }
-      },
-      "body": {
-        "text": {
-          "color": {
-            "base": {
-              "description": "",
-              "type": "color",
-              "value": "{semantics.typography.color.darkest}"
-            },
-            "highlight": {
-              "description": "",
-              "type": "color",
-              "value": "{semantics.typography.color.lightest}"
-            }
-          }
-        }
-      }
-    },
-    "link": {
-      "container": {
-        "gap": {
-          "description": "",
-          "type": "color",
-          "value": "{semantics.navigation.space.small}"
-        },
-        "border": {
-          "width": {
-            "hover": {
-              "description": "",
-              "type": "color",
-              "value": "{semantics.navigation.stroke}"
-            },
-            "action": {
-              "description": "",
-              "type": "color",
-              "value": "{semantics.navigation.stroke}"
-            }
-          },
-          "color": {
-            "hover": {
-              "description": "",
-              "type": "color",
-              "value": "{semantics.navigation.color.bright}"
-            },
-            "action": {
-              "description": "",
-              "type": "color",
-              "value": "{semantics.navigation.color.bright}"
-            }
-          }
-        }
-      },
-      "text": {
-        "color": {
-          "description": "",
-          "type": "color",
-          "value": "{semantics.navigation.color.bright}"
-        }
-      },
-      "icon": {
-        "color": {
-          "description": "",
-          "type": "color",
-          "value": "{semantics.navigation.color.bright}"
-        }
-      }
-    },
-    "feature-box": {
-      "container": {
-        "padding": {
-          "description": "",
-          "type": "color",
-          "value": "{semantics.action.space.medium}"
-        }
-      }
-    },
-    "alert": {
-      "background": {
-        "color": {
-          "success": {
-            "description": "",
-            "type": "color",
-            "value": "{semantics.feedback.color.success.brightest}"
-          },
-          "info": {
-            "description": "",
-            "type": "color",
-            "value": "{semantics.feedback.color.info.brightest}"
-          },
-          "warning": {
-            "description": "",
-            "type": "color",
-            "value": "{semantics.feedback.color.warning.brightest}"
-          }
-        }
-      },
-      "text": {
-        "color": {
-          "success": {
-            "description": "",
-            "type": "color",
-            "value": "{semantics.feedback.color.success.darkest}"
-          },
-          "info": {
-            "description": "",
-            "type": "color",
-            "value": "{semantics.feedback.color.info.darkest}"
-          },
-          "warning": {
-            "description": "",
-            "type": "color",
-            "value": "{semantics.feedback.color.warning.darkest}"
-          }
-        }
-      },
-      "icon": {
-        "color": {
-          "success": {
-            "description": "",
-            "type": "color",
-            "value": "{semantics.feedback.color.success.darkest}"
-          },
-          "info": {
-            "description": "",
-            "type": "color",
-            "value": "{semantics.feedback.color.info.darkest}"
-          },
-          "warning": {
-            "description": "",
-            "type": "color",
-            "value": "{semantics.feedback.color.warning.darkest}"
-          }
-        },
-        "size": {
-          "label": {
-            "description": "",
-            "type": "color",
-            "value": "{semantics.visual.icon.size.small}"
-          },
-          "accordion": {
-            "description": "",
-            "type": "color",
-            "value": "{semantics.visual.icon.size.medium}"
-          },
-          "banner": {
-            "description": "",
-            "type": "color",
-            "value": "{semantics.visual.icon.size.medium}"
-          }
-        }
-      },
-      "container": {
-        "padding": {
-          "top": {
-            "label": {
-              "description": "",
-              "type": "color",
-              "value": "{semantics.feedback.space.small}"
-            },
-            "banner": {
-              "description": "",
-              "type": "color",
-              "value": "{semantics.feedback.space.small}"
-            },
-            "accordion": {
-              "description": "",
-              "type": "color",
-              "value": "{semantics.feedback.space.large}"
-            }
-          },
-          "right": {
-            "label": {
-              "description": "",
-              "type": "color",
-              "value": "{semantics.feedback.space.small}"
-            },
-            "banner": {
-              "description": "",
-              "type": "color",
-              "value": "{semantics.feedback.space.small}"
-            },
-            "accordion": {
-              "description": "",
-              "type": "color",
-              "value": "{semantics.feedback.space.large}"
-            }
-          },
-          "bottom": {
-            "label": {
-              "description": "",
-              "type": "color",
-              "value": "{semantics.feedback.space.small}"
-            },
-            "banner": {
-              "description": "",
-              "type": "color",
-              "value": "{semantics.feedback.space.small}"
-            },
-            "accordion": {
-              "description": "",
-              "type": "color",
-              "value": "{semantics.feedback.space.large}"
-            }
-          },
-          "left": {
-            "label": {
-              "description": "",
-              "type": "color",
-              "value": "{semantics.feedback.space.small}"
-            },
-            "banner": {
-              "description": "",
-              "type": "color",
-              "value": "{semantics.feedback.space.large}"
-            },
-            "accordion": {
-              "description": "",
-              "type": "color",
-              "value": "{semantics.feedback.space.large}"
-            }
-          }
-        },
-        "gap": {
-          "label": {
-            "description": "",
-            "type": "color",
-            "value": "{semantics.feedback.space.xsmall}"
-          }
-        },
-        "border": {
-          "radius": {
-            "label": {
-              "description": "",
-              "type": "color",
-              "value": "{semantics.feedback.radius.small}"
-            },
-            "banner": {
-              "description": "",
-              "type": "color",
-              "value": "{semantics.feedback.radius.medium}"
-            },
-            "accordion": {
-              "description": "",
-              "type": "color",
-              "value": "{semantics.feedback.radius.medium}"
-            }
-          }
-        }
-      },
-      "inner-container-left": {
-        "gap": {
-          "banner": {
-            "description": "",
-            "type": "color",
-            "value": "{semantics.feedback.space.medium}"
-          },
-          "accordion": {
-            "vertical": {
-              "description": "",
-              "type": "color",
-              "value": "{semantics.feedback.space.medium}"
-            },
-            "horizontal": {
-              "description": "",
-              "type": "color",
-              "value": "{semantics.feedback.space.xlarge}"
-            }
-          }
-        }
-      },
-      "inner-container-right": {
-        "padding": {
-          "right": {
-            "description": "",
-            "type": "color",
-            "value": "{semantics.feedback.space.small}"
-          }
-        }
-      }
-    }
-  },
-  "global": {
-    "focus": {
-      "border": {
-        "radius": {
-          "xsmall": {
-            "description": "",
-            "type": "color",
-            "value": "{semantics.layout.element.radius.xsmall}"
-          },
-          "small": {
-            "description": "",
-            "type": "color",
-            "value": "{semantics.layout.element.radius.small}"
-          },
-          "medium": {
-            "description": "",
-            "type": "color",
-            "value": "{semantics.layout.element.radius.medium}"
-          },
-          "large": {
-            "description": "",
-            "type": "color",
-            "value": "{semantics.layout.element.radius.large}"
-          },
-          "xlarge": {
-            "description": "",
-            "type": "color",
-            "value": "{semantics.layout.element.radius.xlarge}"
-          },
-          "pill": {
-            "description": "",
-            "type": "color",
-            "value": "{semantics.layout.element.radius.pill}"
-          }
-        },
-        "width": {
-          "description": "",
-          "type": "color",
-          "value": "{semantics.layout.element.stroke.thick}"
-        }
-      },
-      "color": {
-        "description": "",
-        "type": "color",
-        "value": "{semantics.color.ui.informative.informative-450}"
-      }
-    },
-    "text": {
-      "primary": {
-        "size": {
-          "display": {
-            "large": {
-              "description": "",
-              "type": "color",
-              "value": "{semantics.typography.size.64}"
-            },
-            "medium": {
-              "description": "",
-              "type": "color",
-              "value": "{semantics.typography.size.56}"
-            },
-            "small": {
-              "description": "",
-              "type": "color",
-              "value": "{semantics.typography.size.48}"
-            }
-          },
-          "heading": {
-            "small": {
-              "description": "",
-              "type": "color",
-              "value": "{semantics.typography.size.32}"
-            },
-            "medium": {
-              "description": "",
-              "type": "color",
-              "value": "{semantics.typography.size.40}"
-            }
-          },
-          "title": {
-            "small": {
-              "description": "",
-              "type": "color",
-              "value": "{semantics.typography.size.20}"
-            },
-            "medium": {
-              "description": "",
-              "type": "color",
-              "value": "{semantics.typography.size.24}"
-            }
-          },
-          "body": {
-            "description": "",
-            "type": "color",
-            "value": "{semantics.typography.size.16}"
-          },
-          "label": {
-            "small": {
-              "description": "",
-              "type": "color",
-              "value": "{semantics.typography.size.12}"
-            },
-            "medium": {
-              "description": "",
-              "type": "color",
-              "value": "{semantics.typography.size.14}"
-            }
-          }
-        },
-        "line-height": {
-          "display": {
-            "large": {
-              "description": "",
-              "type": "color",
-              "value": "{semantics.typography.line-height.80}"
-            },
-            "medium": {
-              "description": "",
-              "type": "color",
-              "value": "{semantics.typography.line-height.70}"
-            },
-            "small": {
-              "description": "",
-              "type": "color",
-              "value": "{semantics.typography.line-height.60}"
-            }
-          },
-          "body": {
-            "description": "",
-            "type": "color",
-            "value": "{semantics.typography.line-height.25}"
-          },
-          "label": {
-            "small": {
-              "description": "",
-              "type": "color",
-              "value": "{semantics.typography.line-height.20}"
-            },
-            "medium": {
-              "description": "",
-              "type": "color",
-              "value": "{semantics.typography.line-height.25}"
-            }
-          },
-          "heading": {
-            "small": {
-              "description": "",
-              "type": "color",
-              "value": "{semantics.typography.line-height.50}"
-            },
-            "medium": {
-              "description": "",
-              "type": "color",
-              "value": "{semantics.typography.line-height.60}"
-            }
-          },
-          "title": {
-            "small": {
-              "description": "",
-              "type": "color",
-              "value": "{semantics.typography.line-height.35}"
-            },
-            "medium": {
-              "description": "",
-              "type": "color",
-              "value": "{semantics.typography.line-height.40}"
-            }
-          }
-        },
-        "weight": {
-          "display": {
-            "small": {
-              "small": {
-                "description": "",
-                "type": "color",
-                "value": "{semantics.typography.weight.book}"
-              }
-            },
-            "large": {
-              "large": {
-                "description": "",
-                "type": "color",
-                "value": "{semantics.typography.weight.regular}"
-              }
-            },
-            "medium": {
-              "medium": {
-                "description": "",
-                "type": "color",
-                "value": "{semantics.typography.weight.book}"
-              }
-            }
-          },
-          "heading": {
-            "small": {
-              "small": {
-                "description": "",
-                "type": "color",
-                "value": "{semantics.typography.weight.regular}"
-              }
-            },
-            "medium": {
-              "medium": {
-                "description": "",
-                "type": "color",
-                "value": "{semantics.typography.weight.book}"
-              }
-            }
-          },
-          "title": {
-            "small": {
-              "small": {
-                "description": "",
-                "type": "color",
-                "value": "{semantics.typography.weight.regular}"
-              }
-            },
-            "medium": {
-              "medium": {
-                "description": "",
-                "type": "color",
-                "value": "{semantics.typography.weight.regular}"
-              }
-            }
-          },
-          "label": {
-            "small": {
-              "small": {
-                "description": "",
-                "type": "color",
-                "value": "{semantics.typography.weight.regular}"
-              }
-            },
-            "medium": {
-              "medium": {
-                "description": "",
-                "type": "color",
-                "value": "{semantics.typography.weight.regular}"
-              }
-            }
-          },
-          "body": {
-            "description": "",
-            "type": "color",
-            "value": "{semantics.typography.weight.regular}"
-          }
-        },
-        "font-familty": {
-          "description": "",
-          "type": "color",
-          "value": "{semantics.typography.font-family.pp-mori}"
-        }
-      },
-      "secondary": {
-        "font-familty": {
-          "description": "",
-          "type": "color",
-          "value": "{semantics.typography.font-family.lyon-display}"
-        },
-        "line-height": {
-          "display": {
-            "large": {
-              "description": "",
-              "type": "color",
-              "value": "{semantics.typography.line-height.80}"
-            },
-            "medium": {
-              "description": "",
-              "type": "color",
-              "value": "{semantics.typography.line-height.70}"
-            },
-            "small": {
-              "description": "",
-              "type": "color",
-              "value": "{semantics.typography.line-height.60}"
-            }
-          },
-          "heading": {
-            "medium": {
-              "description": "",
-              "type": "color",
-              "value": "{semantics.typography.line-height.50}"
-            },
-            "small": {
-              "description": "",
-              "type": "color",
-              "value": "{semantics.typography.line-height.40}"
-            }
-          }
-        },
-        "size": {
-          "display": {
-            "large": {
-              "description": "",
-              "type": "color",
-              "value": "{semantics.typography.size.64}"
-            },
-            "medium": {
-              "description": "",
-              "type": "color",
-              "value": "{semantics.typography.size.56}"
-            },
-            "small": {
-              "description": "",
-              "type": "color",
-              "value": "{semantics.typography.size.48}"
-            }
-          },
-          "heading": {
-            "small": {
-              "description": "",
-              "type": "color",
-              "value": "{semantics.typography.size.32}"
-            },
-            "medium": {
-              "description": "",
-              "type": "color",
-              "value": "{semantics.typography.size.40}"
-            }
-          }
-        },
-        "weight": {
-          "display": {
-            "small": {
-              "description": "",
-              "type": "color",
-              "value": "{semantics.typography.weight.light}"
-            },
-            "large": {
-              "description": "",
-              "type": "color",
-              "value": "{semantics.typography.weight.light}"
-            },
-            "medium": {
-              "description": "",
-              "type": "color",
-              "value": "{semantics.typography.weight.light}"
-            }
-          },
-          "heading": {
-            "small": {
-              "description": "",
-              "type": "color",
-              "value": "{semantics.typography.weight.light}"
-            },
-            "medium": {
-              "description": "",
-              "type": "color",
-              "value": "{semantics.typography.weight.regular}"
-            }
-          }
-        }
-      },
-      "reading": {
-        "font-familty": {
-          "description": "",
-          "type": "color",
-          "value": "{semantics.typography.font-family.inter}"
-        },
-        "line-height": {
-          "body": {
-            "description": "",
-            "type": "color",
-            "value": "{semantics.typography.line-height.25}"
-          },
-          "heading": {
-            "medium": {
-              "description": "",
-              "type": "color",
-              "value": "{semantics.typography.line-height.50}"
-            },
-            "small": {
-              "description": "",
-              "type": "color",
-              "value": "{semantics.typography.line-height.40}"
-            }
-          },
-          "title": {
-            "medium": {
-              "description": "",
-              "type": "color",
-              "value": "{semantics.typography.line-height.35}"
-            },
-            "small": {
-              "description": "",
-              "type": "color",
-              "value": "{semantics.typography.line-height.30}"
-            }
-          },
-          "label": {
-            "medium": {
-              "description": "",
-              "type": "color",
-              "value": "{semantics.typography.line-height.20}"
-            },
-            "small": {
-              "description": "",
-              "type": "color",
-              "value": "{semantics.typography.line-height.20}"
-            }
-          }
-        },
-        "size": {
-          "body": {
-            "description": "",
-            "type": "color",
-            "value": "{semantics.typography.size.16}"
-          },
-          "heading": {
-            "small": {
-              "description": "",
-              "type": "color",
-              "value": "{semantics.typography.size.32}"
-            },
-            "medium": {
-              "description": "",
-              "type": "color",
-              "value": "{semantics.typography.size.40}"
-            }
-          },
-          "title": {
-            "small": {
-              "description": "",
-              "type": "color",
-              "value": "{semantics.typography.size.20}"
-            },
-            "medium": {
-              "description": "",
-              "type": "color",
-              "value": "{semantics.typography.size.24}"
-            }
-          },
-          "label": {
-            "small": {
-              "description": "",
-              "type": "color",
-              "value": "{semantics.typography.size.12}"
-            },
-            "medium": {
-              "description": "",
-              "type": "color",
-              "value": "{semantics.typography.size.14}"
-            }
-          }
-        },
-        "weight": {
-          "body": {
-            "description": "",
-            "type": "color",
-            "value": "{semantics.typography.weight.regular}"
-          },
-          "heading": {
-            "small": {
-              "description": "",
-              "type": "color",
-              "value": "{semantics.typography.weight.regular}"
-            },
-            "medium": {
-              "description": "",
-              "type": "color",
-              "value": "{semantics.typography.weight.book}"
-            }
-          },
-          "title": {
-            "small": {
-              "description": "",
-              "type": "color",
-              "value": "{semantics.typography.weight.regular}"
-            },
-            "medium": {
-              "description": "",
-              "type": "color",
-              "value": "{semantics.typography.weight.regular}"
-            }
-          },
-          "label": {
-            "small": {
-              "description": "",
-              "type": "color",
-              "value": "{semantics.typography.weight.regular}"
-            },
-            "medium": {
-              "description": "",
-              "type": "color",
-              "value": "{semantics.typography.weight.regular}"
-            }
+            "value": "{primitives.color.lawblue.90}"
           }
         }
       },
       "ui": {
-        "font-familty": {
-          "description": "",
-          "type": "color",
-          "value": "{semantics.typography.font-family.pp-mori}"
+        "success": {
+          "success-125": {
+            "description": "",
+            "type": "color",
+            "value": "{primitives.color.green.125}"
+          },
+          "success-175": {
+            "description": "",
+            "type": "color",
+            "value": "{primitives.color.green.175}"
+          },
+          "success-75": {
+            "description": "",
+            "type": "color",
+            "value": "{primitives.color.green.75}"
+          },
+          "success-450": {
+            "description": "",
+            "type": "color",
+            "value": "{primitives.color.green.450}"
+          },
+          "success-700": {
+            "description": "",
+            "type": "color",
+            "value": "{primitives.color.green.700}"
+          }
         },
+        "informative": {
+          "informative-25": {
+            "description": "",
+            "type": "color",
+            "value": "{primitives.color.purple.25}"
+          },
+          "informative-125": {
+            "description": "",
+            "type": "color",
+            "value": "{primitives.color.purple.125}"
+          },
+          "informative-450": {
+            "description": "",
+            "type": "color",
+            "value": "{primitives.color.purple.450}"
+          },
+          "informative-175": {
+            "description": "",
+            "type": "color",
+            "value": "{primitives.color.purple.175}"
+          },
+          "informative-700": {
+            "description": "",
+            "type": "color",
+            "value": "{primitives.color.purple.700}"
+          }
+        },
+        "warning": {
+          "warning-125": {
+            "description": "",
+            "type": "color",
+            "value": "{primitives.color.orange.125}"
+          },
+          "warning-175": {
+            "description": "",
+            "type": "color",
+            "value": "{primitives.color.orange.175}"
+          },
+          "warning-450": {
+            "description": "",
+            "type": "color",
+            "value": "{primitives.color.orange.450}"
+          },
+          "warning-75": {
+            "description": "",
+            "type": "color",
+            "value": "{primitives.color.orange.75}"
+          },
+          "warning-700": {
+            "description": "",
+            "type": "color",
+            "value": "{primitives.color.orange.700}"
+          }
+        }
+      },
+      "theme": {
+        "nostalgia": {
+          "nostalgia-25": {
+            "description": "",
+            "type": "color",
+            "value": "{primitives.color.nostalgia.25}"
+          },
+          "nostalgia-600": {
+            "description": "",
+            "type": "color",
+            "value": "{primitives.color.nostalgia.600}"
+          },
+          "nostalgia-850": {
+            "description": "",
+            "type": "color",
+            "value": "{primitives.color.nostalgia.850}"
+          }
+        },
+        "nature": {
+          "nature-750": {
+            "description": "",
+            "type": "color",
+            "value": "{primitives.color.nature.750}"
+          },
+          "nature-525": {
+            "description": "",
+            "type": "color",
+            "value": "{primitives.color.nature.525}"
+          },
+          "nature-25": {
+            "description": "",
+            "type": "color",
+            "value": "{primitives.color.nature.25}"
+          }
+        },
+        "romance": {
+          "romance-750": {
+            "description": "",
+            "type": "color",
+            "value": "{primitives.color.romance.750}"
+          },
+          "romance-675": {
+            "description": "",
+            "type": "color",
+            "value": "{primitives.color.romance.675}"
+          },
+          "romance-50": {
+            "description": "",
+            "type": "color",
+            "value": "{primitives.color.romance.50}"
+          }
+        },
+        "vacation": {
+          "vacation-150": {
+            "description": "",
+            "type": "color",
+            "value": "{primitives.color.vacation.150}"
+          },
+          "vacation-600": {
+            "description": "",
+            "type": "color",
+            "value": "{primitives.color.vacation.600}"
+          },
+          "vacation-25": {
+            "description": "",
+            "type": "color",
+            "value": "{primitives.color.vacation.25}"
+          }
+        },
+        "fantasy": {
+          "fantasy-750": {
+            "description": "",
+            "type": "color",
+            "value": "{primitives.color.fantasy.750}"
+          },
+          "fantasy-850": {
+            "description": "",
+            "type": "color",
+            "value": "{primitives.color.fantasy.850}"
+          },
+          "fantasy-250": {
+            "description": "",
+            "type": "color",
+            "value": "{primitives.color.fantasy.250}"
+          }
+        },
+        "thriller": {
+          "thriller-900": {
+            "description": "",
+            "type": "color",
+            "value": "{primitives.color.thriller.900}"
+          },
+          "thriller-750": {
+            "description": "",
+            "type": "color",
+            "value": "{primitives.color.thriller.850}"
+          },
+          "thriller-250": {
+            "description": "",
+            "type": "color",
+            "value": "{primitives.color.thriller.250}"
+          }
+        }
+      }
+    },
+    "layout": {
+      "page": {
+        "space": {
+          "xlarge": {
+            "description": "",
+            "type": "dimension",
+            "value": "{primitives.size.64}"
+          },
+          "large": {
+            "description": "",
+            "type": "dimension",
+            "value": "{primitives.size.48}"
+          },
+          "xxlarge": {
+            "description": "",
+            "type": "dimension",
+            "value": "{primitives.size.128}"
+          },
+          "medium": {
+            "description": "",
+            "type": "dimension",
+            "value": "{primitives.size.40}"
+          },
+          "small": {
+            "description": "",
+            "type": "dimension",
+            "value": "{primitives.size.32}"
+          },
+          "xsmall": {
+            "description": "",
+            "type": "dimension",
+            "value": "{primitives.size.24}"
+          },
+          "xxsmall": {
+            "description": "",
+            "type": "dimension",
+            "value": "{primitives.size.16}"
+          }
+        },
+        "width": {
+          "max": {
+            "description": "",
+            "type": "dimension",
+            "value": "{primitives.size.1600}"
+          },
+          "min": {
+            "description": "",
+            "type": "dimension",
+            "value": "{primitives.size.320}"
+          }
+        }
+      },
+      "element": {
         "size": {
-          "input": {
+          "large": {
             "description": "",
-            "type": "color",
-            "value": "{semantics.typography.size.16}"
+            "type": "dimension",
+            "value": "{primitives.size.40}"
           },
-          "button": {
+          "medium": {
             "description": "",
-            "type": "color",
-            "value": "{semantics.typography.size.16}"
+            "type": "dimension",
+            "value": "{primitives.size.32}"
           },
-          "label": {
-            "medium": {
-              "description": "",
-              "type": "color",
-              "value": "{semantics.typography.size.14}"
-            },
-            "small": {
-              "description": "",
-              "type": "color",
-              "value": "{semantics.typography.size.12}"
-            },
-            "large": {
-              "description": "",
-              "type": "color",
-              "value": "{semantics.typography.size.16}"
-            }
+          "small": {
+            "description": "",
+            "type": "dimension",
+            "value": "{primitives.size.24}"
+          },
+          "xlarge": {
+            "description": "",
+            "type": "dimension",
+            "value": "{primitives.size.48}"
+          },
+          "xsmall": {
+            "description": "",
+            "type": "dimension",
+            "value": "{primitives.size.16}"
           }
         },
-        "line-height": {
-          "input": {
+        "space": {
+          "large": {
             "description": "",
-            "type": "color",
-            "value": "{semantics.typography.line-height.25}"
+            "type": "dimension",
+            "value": "{primitives.size.24}"
           },
-          "label": {
-            "medium": {
-              "multi-line": {
-                "description": "",
-                "type": "color",
-                "value": "{semantics.typography.line-height.25}"
-              }
-            },
-            "small": {
-              "multi-line": {
-                "description": "",
-                "type": "color",
-                "value": "{semantics.typography.line-height.20}"
-              }
-            },
-            "large": {
-              "multi-line": {
-                "description": "",
-                "type": "color",
-                "value": "{semantics.typography.line-height.25}"
-              }
-            }
+          "medium": {
+            "description": "",
+            "type": "dimension",
+            "value": "{primitives.size.16}"
+          },
+          "small": {
+            "description": "",
+            "type": "dimension",
+            "value": "{primitives.size.12}"
+          },
+          "xsmall": {
+            "description": "",
+            "type": "dimension",
+            "value": "{primitives.size.8}"
+          },
+          "xxlarge": {
+            "description": "",
+            "type": "dimension",
+            "value": "{primitives.size.40}"
+          },
+          "xlarge": {
+            "description": "",
+            "type": "dimension",
+            "value": "{primitives.size.32}"
+          },
+          "xxsmall": {
+            "description": "",
+            "type": "dimension",
+            "value": "{primitives.size.4}"
+          },
+          "xxxlarge": {
+            "description": "",
+            "type": "dimension",
+            "value": "{primitives.size.64}"
+          },
+          "tiny": {
+            "description": "",
+            "type": "dimension",
+            "value": "{primitives.size.2}"
           }
         },
-        "weight": {
-          "input": {
+        "stroke": {
+          "fat": {
             "description": "",
-            "type": "color",
-            "value": "{semantics.typography.weight.regular}"
+            "type": "dimension",
+            "value": "{primitives.size.4}"
           },
-          "button": {
+          "thick": {
             "description": "",
-            "type": "color",
-            "value": "{semantics.typography.weight.regular}"
+            "type": "dimension",
+            "value": "{primitives.size.2}"
           },
-          "label": {
-            "small": {
-              "description": "",
-              "type": "color",
-              "value": "{semantics.typography.weight.regular}"
-            },
-            "medium": {
-              "description": "",
-              "type": "color",
-              "value": "{semantics.typography.weight.regular}"
-            },
-            "large": {
-              "description": "",
-              "type": "color",
-              "value": "{semantics.typography.weight.regular}"
-            }
+          "regular": {
+            "description": "",
+            "type": "dimension",
+            "value": "{primitives.size.1}"
+          }
+        },
+        "radius": {
+          "pill": {
+            "description": "",
+            "type": "dimension",
+            "value": "{primitives.size.1000}"
+          },
+          "xlarge": {
+            "description": "",
+            "type": "dimension",
+            "value": "{primitives.size.32}"
+          },
+          "large": {
+            "description": "",
+            "type": "dimension",
+            "value": "{primitives.size.24}"
+          },
+          "medium": {
+            "description": "",
+            "type": "dimension",
+            "value": "{primitives.size.16}"
+          },
+          "small": {
+            "description": "",
+            "type": "dimension",
+            "value": "{primitives.size.10}"
+          },
+          "xsmall": {
+            "description": "",
+            "type": "dimension",
+            "value": "{primitives.size.8}"
           }
         }
       }
     },
-    "disabled": {
-      "container": {
-        "opacity": {
-          "description": "",
-          "type": "dimension",
-          "value": "{primitives.transparency.50}"
-        }
-      }
-    },
-    "hover": {
-      "container": {
-        "lighten": {
-          "description": "",
-          "type": "color",
-          "value": "{semantics.color.identity.base.aubergine-1000}"
-        },
-        "darken": {
-          "description": "",
-          "type": "color",
-          "value": "{semantics.color.identity.base.aubergine-50}"
-        },
-        "opacity": {
-          "description": "",
-          "type": "dimension",
-          "value": "{primitives.transparency.10}"
-        }
-      }
-    }
-  },
-  "template": {
-    "text-wrapper": {
-      "gap": {
-        "horizontal": {
-          "description": "",
-          "type": "color",
-          "value": "{semantics.typography.space.medium}"
-        }
-      }
-    },
-    "main": {
-      "gap": {
-        "min": {
-          "description": "",
-          "type": "color",
-          "value": "{semantics.layout.page.space.xxsmall}"
-        },
-        "max": {
-          "description": "",
-          "type": "color",
-          "value": "{semantics.layout.page.space.small}"
-        }
-      },
-      "padding": {
-        "min": {
-          "description": "",
-          "type": "color",
-          "value": "{semantics.layout.page.space.xxsmall}"
-        },
-        "max": {
-          "description": "",
-          "type": "color",
-          "value": "{semantics.layout.page.space.small}"
-        }
-      },
-      "width": {
-        "min": {
-          "description": "",
-          "type": "dimension",
-          "value": "{primitives.size.320}"
-        },
-        "max": {
-          "description": "",
-          "type": "dimension",
-          "value": "{primitives.size.1600}"
-        }
-      }
-    },
-    "page": {
-      "gap": {
-        "min": {
-          "description": "",
-          "type": "color",
-          "value": "{semantics.layout.page.space.xxsmall}"
-        },
-        "max": {
-          "description": "",
-          "type": "color",
-          "value": "{semantics.layout.page.space.small}"
-        }
-      },
-      "width": {
-        "min": {
-          "description": "",
-          "type": "color",
-          "value": "{semantics.layout.page.width.min}"
-        },
-        "max": {
-          "description": "",
-          "type": "color",
-          "value": "{semantics.layout.page.width.max}"
+    "visual": {
+      "icon": {
+        "size": {
+          "small": {
+            "description": "",
+            "type": "dimension",
+            "value": "{primitives.size.16}"
+          },
+          "regular": {
+            "description": "",
+            "type": "dimension",
+            "value": "{primitives.size.20}"
+          }
         }
       }
     }

--- a/packages/kobber-base/tokens-from-figma/design-tokens.tokens.json
+++ b/packages/kobber-base/tokens-from-figma/design-tokens.tokens.json
@@ -1911,7 +1911,7 @@
             "small": {
               "description": "",
               "type": "color",
-              "value": "{global.visual.icon.size.regular}"
+              "value": "{global.visual.icon.size.small}"
             }
           }
         }
@@ -5350,14 +5350,14 @@
             "value": "{global.typography.weight.regular}"
           }
         },
-        "font-familty": {
+        "font-family": {
           "description": "",
           "type": "color",
           "value": "{global.typography.font-family.pp-mori}"
         }
       },
       "secondary": {
-        "font-familty": {
+        "font-family": {
           "description": "",
           "type": "color",
           "value": "{global.typography.font-family.lyon-display}"
@@ -5457,7 +5457,7 @@
         }
       },
       "reading": {
-        "font-familty": {
+        "font-family": {
           "description": "",
           "type": "color",
           "value": "{global.typography.font-family.inter}"
@@ -5593,7 +5593,7 @@
         }
       },
       "ui": {
-        "font-familty": {
+        "font-family": {
           "description": "",
           "type": "color",
           "value": "{global.typography.font-family.pp-mori}"

--- a/packages/kobber-base/tokens-from-figma/design-tokens.tokens.json
+++ b/packages/kobber-base/tokens-from-figma/design-tokens.tokens.json
@@ -5968,17 +5968,17 @@
         "large": {
           "description": "",
           "type": "color",
-          "value": "{regional.layout.element.space.large}"
+          "value": "{global.layout.element.space.large}"
         },
         "medium": {
           "description": "",
           "type": "color",
-          "value": "{regional.layout.element.space.medium}"
+          "value": "{global.layout.element.space.medium}"
         },
         "small": {
           "description": "",
           "type": "color",
-          "value": "{regional.layout.element.space.xsmall}"
+          "value": "{global.layout.element.space.xsmall}"
         }
       }
     },

--- a/packages/kobber-components/src/accordion/Accordion.styles.ts
+++ b/packages/kobber-components/src/accordion/Accordion.styles.ts
@@ -4,7 +4,7 @@ import { accordionClassNames } from "./Accordion.core";
 
 export const accordionStyles = css`
   .${unsafeCSS(accordionClassNames("kobber-accordion"))} {
-    border-radius: var(${unsafeCSS(component["wiki-list-item"].container.border.radius)});
+    border-radius: var(${unsafeCSS(component["docs-list-item"].container.border.radius)});
     font-family: PP Mori;
   }
 

--- a/packages/kobber-components/src/button/Button.core.ts
+++ b/packages/kobber-components/src/button/Button.core.ts
@@ -1,4 +1,4 @@
-import { component, semantics } from "@gyldendal/kobber-base/themes/default/tokens.js";
+import { component, global } from "@gyldendal/kobber-base/themes/default/tokens.js";
 import { ReplaceSpaceWithDash, replaceSpaceWithDash } from "../utils/replace";
 
 export const buttonName = "kobber-button";
@@ -71,9 +71,9 @@ export const buttonVariants: ButtonVariant[] = Object.keys(
 ) as ButtonVariant[];
 export const buttonLevels: ButtonLevel[] = Object.keys(component.button.text.color.neutral.main) as ButtonLevel[];
 
-export type ButtonUiColor = keyof typeof semantics.color.ui;
+export type ButtonUiColor = keyof typeof global.color.ui;
 export const isUiColor = (color: ButtonColor | undefined): color is ButtonUiColor =>
-  !!color && color in semantics.color.ui;
+  !!color && color in global.color.ui;
 
 export const hasSupplementalAlt = (color: ButtonColor | undefined) =>
   color === "aubergine" || color === "rettsdata" || color === "neutral";

--- a/packages/kobber-components/src/button/Button.styles.ts
+++ b/packages/kobber-components/src/button/Button.styles.ts
@@ -1,5 +1,5 @@
 import { css, unsafeCSS } from "lit";
-import { component, global, typography } from "@gyldendal/kobber-base/themes/default/tokens.css-variables.js";
+import { component, universal, typography } from "@gyldendal/kobber-base/themes/default/tokens.css-variables.js";
 import {
   buttonColors,
   buttonVariants,
@@ -47,7 +47,7 @@ const createButtonStyles = () => {
       &[disabled],
       &.disabled {
         /* TODO: wait for tokens to expose percent as number, not rem */
-        /* opacity: var(${unsafeCSS(global.disabled.container.opacity)}); */
+        /* opacity: var(${unsafeCSS(universal.disabled.container.opacity)}); */
         opacity: 0.5;
         cursor: auto;
       }
@@ -55,7 +55,7 @@ const createButtonStyles = () => {
       &:focus-visible,
       &.focus {
         outline: none;
-        box-shadow: 0 0 0 var(${unsafeCSS(global.focus.border.width)}) var(${unsafeCSS(global.focus.color)});
+        box-shadow: 0 0 0 var(${unsafeCSS(universal.focus.border.width)}) var(${unsafeCSS(universal.focus.color)});
       }
 
       &.${unsafeCSS("icon" satisfies ButtonClassNames)} {

--- a/packages/kobber-components/src/checkbox/Checkbox.stories.ts
+++ b/packages/kobber-components/src/checkbox/Checkbox.stories.ts
@@ -54,8 +54,8 @@ export const Checkbox: Story = {
           const sheet = new CSSStyleSheet();
           sheet.replaceSync(
             ".form-control__help-text { color: ${args.disabled
-              ? "var(--kobber-semantic-action-color-default-disabled-foreground)"
-              : "var(--kobber-semantic-action-color-default-default-foreground)"};font-style: italic;}",
+              ? "var(--kobber-regional-action-color-default-disabled-foreground)"
+              : "var(--kobber-regional-action-color-default-default-foreground)"};font-style: italic;}",
           );
 
           const elemStyleSheets = checkbox.shadowRoot.adoptedStyleSheets;

--- a/packages/kobber-components/src/checkbox/checkbox.styles.ts
+++ b/packages/kobber-components/src/checkbox/checkbox.styles.ts
@@ -73,14 +73,14 @@ export default css`
 
   /* Focus */
   .checkbox:not(.checkbox--checked):not(.checkbox--disabled) .checkbox__input:focus-visible ~ .checkbox__control {
-    box-shadow: 0px 0px 0px 3px var(--kobber-semantic-color-focus);
+    box-shadow: 0px 0px 0px 3px var(--kobber-universal-color-focus);
     outline-offset: 0px;
   }
 
   /* Checked/indeterminate + focus */
   .checkbox.checkbox--checked:not(.checkbox--disabled) .checkbox__input:focus-visible ~ .checkbox__control,
   .checkbox.checkbox--indeterminate:not(.checkbox--disabled) .checkbox__input:focus-visible ~ .checkbox__control {
-    box-shadow: 0px 0px 0px 3px var(--kobber-semantic-color-focus);
+    box-shadow: 0px 0px 0px 3px var(--kobber-universal-color-focus);
     outline-offset: 0px;
   }
 

--- a/packages/kobber-components/src/list/List.styles.ts
+++ b/packages/kobber-components/src/list/List.styles.ts
@@ -9,7 +9,7 @@ const createListStyles = () => {
       flex-direction: column;
       align-items: stretch;
       list-style-type: none;
-      gap: var(${unsafeCSS(component["wiki-side-menu"].container.gap)});
+      gap: var(${unsafeCSS(component["docs-side-menu"].container.gap)});
       width: 100%;
       font-family: PP Mori;
 

--- a/packages/kobber-components/src/list/ListItem.styles.ts
+++ b/packages/kobber-components/src/list/ListItem.styles.ts
@@ -1,9 +1,9 @@
-import { component, global, typography } from "@gyldendal/kobber-base/themes/default/tokens.css-variables";
+import { component, typography, universal } from "@gyldendal/kobber-base/themes/default/tokens.css-variables";
 import { css, unsafeCSS } from "lit";
 import { listItemClassNames, listItemName } from "./ListItem.core";
 
 const createListItemStyles = () => {
-  const listItem = component["wiki-list-item"];
+  const listItem = component["docs-list-item"];
   return css`
     .${unsafeCSS(listItemClassNames(listItemName))} {
       display: flex;
@@ -19,7 +19,7 @@ const createListItemStyles = () => {
       &:focus-visible,
       &.focus {
         outline: none;
-        box-shadow: 0 0 0 var(${unsafeCSS(global.focus.border.width)}) var(${unsafeCSS(global.focus.color)});
+        box-shadow: 0 0 0 var(${unsafeCSS(universal.focus.border.width)}) var(${unsafeCSS(universal.focus.color)});
       }
 
       &[disabled],

--- a/packages/kobber-components/src/progress-bar/ProgressBar.stories.ts
+++ b/packages/kobber-components/src/progress-bar/ProgressBar.stories.ts
@@ -49,7 +49,7 @@ const getFillColor = (args: Args) => {
     return "var(--kobber-component-progressbar-color-foreground-default-primary)";
   }
   if (args.__progressColor === "unknown") {
-    return "var(--kobber-semantic-progress-color-foreground-unknown)";
+    return "var(--kobber-regional-progress-color-foreground-unknown)";
   }
   return `var(--kobber-component-progressbar-color-foreground-${args.__progressColor})`;
 };

--- a/packages/kobber-components/src/story/story-summary.ts
+++ b/packages/kobber-components/src/story/story-summary.ts
@@ -1,5 +1,5 @@
 import { html } from "lit";
-import { semantics } from "@gyldendal/kobber-base/themes/default/tokens";
+import { regional } from "@gyldendal/kobber-base/themes/default/tokens";
 
 type Props = {
   summary: string;
@@ -7,7 +7,10 @@ type Props = {
 };
 
 export const storySummary = ({ summary, code }: Props) => {
-  return html`<div style="position: absolute; top: 1rem; left: 1rem; font-family: monospace; cursor: pointer; background-color: ${semantics.navigation.color.brightest};">
+  return html`<div
+    style="position: absolute; top: 1rem; left: 1rem; font-family: monospace; cursor: pointer; background-color: ${regional
+      .navigation.color.brightest};"
+  >
     <details>
       <summary>${summary}</summary>
       <pre>${code}</pre>

--- a/packages/kobber-components/src/text/Text.stories.ts
+++ b/packages/kobber-components/src/text/Text.stories.ts
@@ -7,7 +7,6 @@ import "./ingress/Ingress";
 import "./link/Link";
 import { headingPrimarySizes, headingSecondarySizes } from "./heading/Heading.core";
 import { textHighlightColors } from "./text-highlight/TextHighlight.core";
-import { template, semantics, component } from "@gyldendal/kobber-base/themes/default/tokens.js";
 import { storySummary } from "../story/story-summary";
 import { textWrapperStyles } from "./text-wrapper/TextWrapper.styles";
 import { linkStyles } from "./link/Link.styles";
@@ -16,6 +15,7 @@ import { getContrast, isContrastCompliant } from "../utils/contrast";
 import { ingressStyles } from "./ingress/Ingress.styles";
 import { headingStyles } from "./heading/Heading.styles";
 import { linkExtendedColors } from "./link/Link.core";
+import { regional, component } from "@gyldendal/kobber-base/themes/default/tokens.css-variables";
 
 const meta: Meta = {
   title: "Text",
@@ -178,8 +178,8 @@ export const Highlight: Story = {
         <kobber-text-wrapper>
           ${textHighlightColors.map((color, i) => {
             const highlightValue = component.button.background.color[color].main.primary.fallback;
-            const backgroundValue = semantics.navigation.color.brightest;
-            const textValue = component.article.body.text.color.base;
+            const backgroundValue = regional.navigation.color.brightest;
+            const textValue = component.body.text.color.base;
 
             const backgroundContrast = getContrast(backgroundValue, highlightValue);
             const backgroundContrastCompliant = isContrastCompliant(backgroundValue, highlightValue, false, "AA");
@@ -277,7 +277,7 @@ export const Wrapper: Story = {
     </div>
 
   ${storySummary({
-    summary: `Wrapper bolker med tekst og gir gap på ${pxToRem(template["text-wrapper"].gap.horizontal)} (${template["text-wrapper"].gap.horizontal}px)`,
+    summary: `Wrapper bolker med tekst og gir gap på ${pxToRem(16)} (${16}px)`,
     code: textWrapperStyles.cssText,
   })}`;
   },

--- a/packages/kobber-components/src/text/heading/Heading.styles.ts
+++ b/packages/kobber-components/src/text/heading/Heading.styles.ts
@@ -12,16 +12,16 @@ import { replaceSpaceWithDash } from "../../utils/replace";
 import { resetHeading } from "../../base/styles/reset.styles";
 
 const createHeadingStyles = () => {
-  const heading = component.article.heading;
+  const heading = component.heading;
 
   return css`
     .${unsafeCSS(headingName)} {
       ${resetHeading()};
 
-      color: var(${unsafeCSS(heading.text.color.h2.base)});
+      color: var(${unsafeCSS(heading.text.color.base)});
 
       &.${unsafeCSS("h1" satisfies HeadingLevel)} {
-        color: var(${unsafeCSS(heading.text.color.h1.base)});
+        color: var(${unsafeCSS(heading.text.color.base)});
       }
 
       &.${unsafeCSS("primary" satisfies HeadingFont)} {

--- a/packages/kobber-components/src/text/ingress/Ingress.styles.ts
+++ b/packages/kobber-components/src/text/ingress/Ingress.styles.ts
@@ -4,7 +4,7 @@ import { component, typography } from "@gyldendal/kobber-base/themes/default/tok
 export const ingressName = "kobber-ingress";
 
 const createIngressStyles = () => {
-  const ingress = component.article.ingress;
+  const ingress = component.ingress;
 
   return css`
     .${unsafeCSS(ingressName)} {

--- a/packages/kobber-components/src/text/link/Link.styles.ts
+++ b/packages/kobber-components/src/text/link/Link.styles.ts
@@ -1,5 +1,5 @@
 import { css, unsafeCSS } from "lit";
-import { component, global } from "@gyldendal/kobber-base/themes/default/tokens.css-variables.js";
+import { component, universal } from "@gyldendal/kobber-base/themes/default/tokens.css-variables.js";
 import { linkName } from "./Link.core";
 import { resetButton } from "../../base/styles/reset.styles";
 
@@ -17,21 +17,21 @@ const createStyles = () => {
       align-items: center;
       text-decoration: none;
       gap: var(${unsafeCSS(link.container.gap)});
-      line-height: var(${unsafeCSS(global.text.ui["line-height"].input)});
+      line-height: var(${unsafeCSS(universal.text.primary["line-height"].body)});
       color: var(${unsafeCSS(link.text.color)});
 
       &.color-text {
-        color: var(${unsafeCSS(component.article.body.text.color.base)});
+        color: var(${unsafeCSS(component["text-link"].text.color)});
       }
 
       &.color-heading {
-        color: var(${unsafeCSS(component.article.heading.text.color.h1.base)});
+        color: var(${unsafeCSS(component["text-link"].text.color)});
       }
 
       &[disabled],
       &.disabled {
         /* TODO: wait for tokens to expose percent as number, not rem */
-        /* opacity: var(${unsafeCSS(global.disabled.container.opacity)}); */
+        /* opacity: var(${unsafeCSS(universal.disabled.container.opacity)}); */
         opacity: 0.5;
         cursor: auto;
       }
@@ -55,8 +55,8 @@ const createStyles = () => {
       &:focus-visible,
       &.focus {
         outline: none;
-        border-radius: var(${unsafeCSS(global.focus.border.radius.xsmall)});
-        box-shadow: 0 0 0 var(${unsafeCSS(global.focus.border.width)}) var(${unsafeCSS(global.focus.color)});
+        border-radius: var(${unsafeCSS(universal.focus.border.radius.xsmall)});
+        box-shadow: 0 0 0 var(${unsafeCSS(universal.focus.border.width)}) var(${unsafeCSS(universal.focus.color)});
         padding-inline: var(${unsafeCSS(link.container.gap)});
 
         &:active,

--- a/packages/kobber-components/src/text/text-highlight/TextHighlight.styles.ts
+++ b/packages/kobber-components/src/text/text-highlight/TextHighlight.styles.ts
@@ -3,11 +3,9 @@ import { component } from "@gyldendal/kobber-base/themes/default/tokens.css-vari
 import { textHighlightColors, textHighlightName } from "./TextHighlight.core";
 
 const createTextHighlightStyles = () => {
-  const article = component.article;
-
   return css`
     .${unsafeCSS(textHighlightName)} {
-      color: var(${unsafeCSS(article.body.text.color.highlight)});
+      color: var(${unsafeCSS(component.body.text.color.highlight)});
 
       ${textHighlightVariableStyles()};
     }

--- a/packages/kobber-components/src/text/text-wrapper/TextWrapper.styles.ts
+++ b/packages/kobber-components/src/text/text-wrapper/TextWrapper.styles.ts
@@ -1,18 +1,17 @@
 import { css, unsafeCSS } from "lit";
-import { component, template, typography } from "@gyldendal/kobber-base/themes/default/tokens.css-variables.js";
+import { component, typography } from "@gyldendal/kobber-base/themes/default/tokens.css-variables.js";
 
 export const textWrapperName = "kobber-text-wrapper";
 
 const createTextWrapperStyles = () => {
-  const textWrapper = template["text-wrapper"];
-  const body = component.article.body;
+  const body = component.body;
   const bodyText = typography.primary.body;
 
   return css`
     .${unsafeCSS(textWrapperName)} {
       display: flex;
       flex-direction: column;
-      gap: var(${unsafeCSS(textWrapper.gap.horizontal)});
+      gap: 1rem;
       color: var(${unsafeCSS(body.text.color.base)});
       font-family: var(${unsafeCSS(bodyText.fontFamily)});
       font-size: var(${unsafeCSS(bodyText.fontSize)});

--- a/packages/kobber-icons/tsup.config.ts
+++ b/packages/kobber-icons/tsup.config.ts
@@ -66,7 +66,7 @@ const makeIconComponents = () => {
     symbols.forEach(symbol => {
       const iconName = getIconNames(symbol.id);
 
-      const constructor = `\n\tconstructor() {\n\t\tsuper();\n\t\tthis.attachShadow({ mode: "open" });\n\t\tthis.heightValueFallback = "var(--kobber-semantics-visual-icon-size-small)";\n\t\tthis.widthValueFallback = "var(--kobber-semantics-visual-icon-size-small)";\n\t}\n\t`;
+      const constructor = `\n\tconstructor() {\n\t\tsuper();\n\t\tthis.attachShadow({ mode: "open" });\n\t\tthis.heightValueFallback = "var(--kobber-global-visual-icon-size-small)";\n\t\tthis.widthValueFallback = "var(--kobber-global-visual-icon-size-small)";\n\t}\n\t`;
       const attributes = `\n\t\tconst ariaLabel =
       this.getAttribute("aria-label") || ""; /* Do not use aria-labelledby, as IDREFs don't work across light DOM and shadow DOM. */\n\t\tconst ariaHidden = ariaLabel === "";\n\t\tconst role = ariaHidden ? "presentation" : "img";`;
       const styles =


### PR DESCRIPTION
- "semantic" collection is now split into "global" and "regional" collections. This major restructuring may cause some errors. 
- "base" collection has renamed to "universal" 
- components with "wiki" in the name has changed to "docs": 
   1. wiki-list-item -> docs-list-item
   2. wiki-side-menu -> docs-side-menu
   3. wiki-navbar -> docs-navbar
   4. wiki-navbar-item -> doc-navbar-item
