### PR TITLE
More radio button corrections

### DIFF
--- a/apps/docs/README.md
+++ b/apps/docs/README.md
@@ -1,6 +1,6 @@
 # kobber.gyldendal.no
 
-### Local setup (from root)
+## Local setup (from root)
 
 Build tokens and components
 
@@ -12,4 +12,13 @@ Run documentation site
 
 ```sh
 yarn dev -F docs
+```
+
+## Local build (from /apps/docs)
+
+Build, then run the built files (as they would run in production).
+
+```sh
+yarn build
+yarn start
 ```

--- a/packages/kobber-components/src/internal-icons/InternalIcons.styles.react.ts
+++ b/packages/kobber-components/src/internal-icons/InternalIcons.styles.react.ts
@@ -1,0 +1,13 @@
+import { css } from "lit";
+
+const createIconStyles = () => {
+  return css`
+    svg {
+      display: block;
+      width: var(--icon-width, 1em);
+      height: var(--icon-height, 1em);
+    }
+  `;
+};
+
+export const internalIconsStyles = createIconStyles();

--- a/packages/kobber-components/src/internal-icons/InternalIcons.styles.ts
+++ b/packages/kobber-components/src/internal-icons/InternalIcons.styles.ts
@@ -1,0 +1,19 @@
+import { css } from "lit";
+
+const createIconStyles = () => {
+  return css`
+    :host {
+      display: block;
+      transform: translate(1px, 1px); /* Necessary for Safari */
+      width: 100%;
+      height: 100%;
+    }
+    svg {
+      display: block;
+      width: var(--icon-width, 1em);
+      height: var(--icon-height, 1em);
+    }
+  `;
+};
+
+export const internalIconsStyles = createIconStyles();

--- a/packages/kobber-components/src/internal-icons/form-checked/index.js
+++ b/packages/kobber-components/src/internal-icons/form-checked/index.js
@@ -1,0 +1,31 @@
+import { internalIconsStyles } from "../InternalIcons.styles";
+
+export class FormChecked extends HTMLElement {
+  constructor() {
+    super();
+    this.attachShadow({ mode: "open" });
+    this.heightValueFallback = "var(--kobber-global-visual-icon-size-small)";
+    this.widthValueFallback = "var(--kobber-global-visual-icon-size-small)";
+  }
+  renderComponent() {
+    const ariaLabel =
+      this.getAttribute("aria-label") ||
+      ""; /* Do not use aria-labelledby, as IDREFs don't work across light DOM and shadow DOM. */
+    const ariaHidden = ariaLabel === "";
+    const role = ariaHidden ? "presentation" : "img";
+    this.shadowRoot.innerHTML = `
+      <style>
+      ${internalIconsStyles}
+      </style>
+			<svg viewBox="0 0 20 20" aria-label="${ariaLabel}" aria-hidden="${ariaHidden}" role="${role}"><path d="M9.14153 15.3415C8.89822 15.3422 8.65719 15.2946 8.4324 15.2015C8.20762 15.1084 8.00355 14.9716 7.83203 14.799L4.51603 11.4825C4.34678 11.3061 4.21409 11.0979 4.12562 10.87C4.03715 10.6421 3.99464 10.3989 4.00054 10.1545C4.00644 9.91013 4.06064 9.6693 4.16001 9.44592C4.25938 9.22255 4.40196 9.02104 4.57953 8.853C4.92372 8.5262 5.38042 8.34431 5.85503 8.345C6.33153 8.345 6.78403 8.525 7.13003 8.852L8.03553 9.75725L8.94103 10.6625L12.6315 5.742C12.8053 5.5119 13.0299 5.32516 13.2879 5.19643C13.5459 5.06769 13.8302 5.00046 14.1185 5C14.522 5 14.906 5.128 15.229 5.37C15.4245 5.51558 15.5892 5.6985 15.7135 5.90818C15.8377 6.11786 15.9192 6.35012 15.953 6.5915C15.9884 6.83274 15.9755 7.07859 15.915 7.3148C15.8546 7.55101 15.7479 7.77287 15.601 7.9675L10.6275 14.6C10.454 14.83 10.2295 15.0167 9.97165 15.1453C9.71382 15.274 9.42968 15.3411 9.14153 15.3415Z" fill="currentColor"></path></svg>`;
+  }
+  connectedCallback() {
+    this.renderComponent();
+  }
+}
+
+export const customElementName = "icon-form_checked";
+
+if (!customElements.get(customElementName)) {
+  customElements.define(customElementName, FormChecked);
+}

--- a/packages/kobber-components/src/internal-icons/form-checked/index.react.tsx
+++ b/packages/kobber-components/src/internal-icons/form-checked/index.react.tsx
@@ -1,0 +1,31 @@
+import { FunctionComponent } from "react";
+import { internalIconsStyles } from "../InternalIcons.styles.react";
+
+type Props = { "aria-label"?: string };
+
+export const InternalIconFormChecked: FunctionComponent<Props> = props => {
+  const ariaLabel =
+    props["aria-label"] || ""; /* Do not use aria-labelledby, as IDREFs don't work across light DOM and shadow DOM. */
+  const ariaHidden = ariaLabel === "";
+  const role = ariaHidden ? "presentation" : "img";
+  return (
+    <>
+      {/* hoists the style element into <head> and deduplicates it */}
+      {/* https://react.dev/reference/react-dom/components/style#rendering-an-inline-css-stylesheet */}
+      {/* have to use dangerousHtml because of encoding, changing ie. & into &amp; */}
+      {/* https://github.com/facebook/react/issues/13838#issuecomment-675270594 */}
+      <style
+        href={"internalIconsStyles"}
+        precedence="medium"
+        dangerouslySetInnerHTML={{ __html: internalIconsStyles.cssText }}
+      ></style>
+      <svg viewBox="0 0 20 20" aria-label={ariaLabel} aria-hidden={ariaHidden} role={role}>
+        <path
+          d="M9.14153 15.3415C8.89822 15.3422 8.65719 15.2946 8.4324 15.2015C8.20762 15.1084 8.00355 14.9716 7.83203 14.799L4.51603 11.4825C4.34678 11.3061 4.21409 11.0979 4.12562 10.87C4.03715 10.6421 3.99464 10.3989 4.00054 10.1545C4.00644 9.91013 4.06064 9.6693 4.16001 9.44592C4.25938 9.22255 4.40196 9.02104 4.57953 8.853C4.92372 8.5262 5.38042 8.34431 5.85503 8.345C6.33153 8.345 6.78403 8.525 7.13003 8.852L8.03553 9.75725L8.94103 10.6625L12.6315 5.742C12.8053 5.5119 13.0299 5.32516 13.2879 5.19643C13.5459 5.06769 13.8302 5.00046 14.1185 5C14.522 5 14.906 5.128 15.229 5.37C15.4245 5.51558 15.5892 5.6985 15.7135 5.90818C15.8377 6.11786 15.9192 6.35012 15.953 6.5915C15.9884 6.83274 15.9755 7.07859 15.915 7.3148C15.8546 7.55101 15.7479 7.77287 15.601 7.9675L10.6275 14.6C10.454 14.83 10.2295 15.0167 9.97165 15.1453C9.71382 15.274 9.42968 15.3411 9.14153 15.3415Z"
+          fill="currentColor"
+        ></path>
+      </svg>
+      `;
+    </>
+  );
+};

--- a/packages/kobber-components/src/internal-icons/form-indeterminate/index.js
+++ b/packages/kobber-components/src/internal-icons/form-indeterminate/index.js
@@ -1,0 +1,31 @@
+import { internalIconsStyles } from "../InternalIcons.styles";
+
+export class FormIndeterminate extends HTMLElement {
+  constructor() {
+    super();
+    this.attachShadow({ mode: "open" });
+    this.heightValueFallback = "var(--kobber-global-visual-icon-size-small)";
+    this.widthValueFallback = "var(--kobber-global-visual-icon-size-small)";
+  }
+  renderComponent() {
+    const ariaLabel =
+      this.getAttribute("aria-label") ||
+      ""; /* Do not use aria-labelledby, as IDREFs don't work across light DOM and shadow DOM. */
+    const ariaHidden = ariaLabel === "";
+    const role = ariaHidden ? "presentation" : "img";
+    this.shadowRoot.innerHTML = `
+      <style>
+      ${internalIconsStyles}
+      </style>
+			<svg viewBox="0 0 20 20" aria-label="${ariaLabel}" aria-hidden="${ariaHidden}" role="${role}"><path d="M6 10H14" stroke="currentColor" stroke-width="4" stroke-linecap="round"></path></svg>`;
+  }
+  connectedCallback() {
+    this.renderComponent();
+  }
+}
+
+export const customElementName = "icon-form_indeterminate";
+
+if (!customElements.get(customElementName)) {
+  customElements.define(customElementName, FormIndeterminate);
+}

--- a/packages/kobber-components/src/internal-icons/form-indeterminate/index.react.tsx
+++ b/packages/kobber-components/src/internal-icons/form-indeterminate/index.react.tsx
@@ -1,0 +1,28 @@
+import { FunctionComponent } from "react";
+import { internalIconsStyles } from "../InternalIcons.styles.react";
+
+type Props = { "aria-label"?: string };
+
+export const InternalIconFormIndeterminate: FunctionComponent<Props> = props => {
+  const ariaLabel =
+    props["aria-label"] || ""; /* Do not use aria-labelledby, as IDREFs don't work across light DOM and shadow DOM. */
+  const ariaHidden = ariaLabel === "";
+  const role = ariaHidden ? "presentation" : "img";
+  return (
+    <>
+      {/* hoists the style element into <head> and deduplicates it */}
+      {/* https://react.dev/reference/react-dom/components/style#rendering-an-inline-css-stylesheet */}
+      {/* have to use dangerousHtml because of encoding, changing ie. & into &amp; */}
+      {/* https://github.com/facebook/react/issues/13838#issuecomment-675270594 */}
+      <style
+        href={"internalIconsStyles"}
+        precedence="medium"
+        dangerouslySetInnerHTML={{ __html: internalIconsStyles.cssText }}
+      ></style>
+      <svg viewBox="0 0 20 20" aria-label={ariaLabel} aria-hidden={ariaHidden} role={role}>
+        <path d="M6 10H14" stroke="currentColor" stroke-width="4" stroke-linecap="round"></path>
+      </svg>
+      `;
+    </>
+  );
+};

--- a/packages/kobber-components/src/internal-icons/form-radio/index.js
+++ b/packages/kobber-components/src/internal-icons/form-radio/index.js
@@ -1,0 +1,31 @@
+import { internalIconsStyles } from "../InternalIcons.styles";
+
+export class FormRadio extends HTMLElement {
+  constructor() {
+    super();
+    this.attachShadow({ mode: "open" });
+    this.heightValueFallback = "var(--kobber-global-visual-icon-size-small)";
+    this.widthValueFallback = "var(--kobber-global-visual-icon-size-small)";
+  }
+  renderComponent() {
+    const ariaLabel =
+      this.getAttribute("aria-label") ||
+      ""; /* Do not use aria-labelledby, as IDREFs don't work across light DOM and shadow DOM. */
+    const ariaHidden = ariaLabel === "";
+    const role = ariaHidden ? "presentation" : "img";
+    this.shadowRoot.innerHTML = `
+      <style>
+      ${internalIconsStyles}
+      </style>
+			<svg viewBox="0 0 10 11" aria-label="${ariaLabel}" aria-hidden="${ariaHidden}" role="${role}"><circle cx="5" cy="5.5" r="5" fill="currentColor"></circle></svg>`;
+  }
+  connectedCallback() {
+    this.renderComponent();
+  }
+}
+
+export const customElementName = "icon-form_radio";
+
+if (!customElements.get(customElementName)) {
+  customElements.define(customElementName, FormRadio);
+}

--- a/packages/kobber-components/src/internal-icons/form-radio/index.react.tsx
+++ b/packages/kobber-components/src/internal-icons/form-radio/index.react.tsx
@@ -1,0 +1,27 @@
+import { FunctionComponent } from "react";
+import { internalIconsStyles } from "../InternalIcons.styles.react";
+
+type Props = { "aria-label"?: string };
+
+export const InternalIconFormRadio: FunctionComponent<Props> = props => {
+  const ariaLabel =
+    props["aria-label"] || ""; /* Do not use aria-labelledby, as IDREFs don't work across light DOM and shadow DOM. */
+  const ariaHidden = ariaLabel === "";
+  const role = ariaHidden ? "presentation" : "img";
+  return (
+    <>
+      {/* hoists the style element into <head> and deduplicates it */}
+      {/* https://react.dev/reference/react-dom/components/style#rendering-an-inline-css-stylesheet */}
+      {/* have to use dangerousHtml because of encoding, changing ie. & into &amp; */}
+      {/* https://github.com/facebook/react/issues/13838#issuecomment-675270594 */}
+      <style
+        href={"internalIconsStyles"}
+        precedence="medium"
+        dangerouslySetInnerHTML={{ __html: internalIconsStyles.cssText }}
+      ></style>
+      <svg viewBox="0 0 10 11" aria-label={ariaLabel} aria-hidden={ariaHidden} role={role}>
+        <circle cx="5" cy="5.5" r="5" fill="currentColor"></circle>
+      </svg>
+    </>
+  );
+};

--- a/packages/kobber-components/src/radio/radioInput/RadioInput.react.tsx
+++ b/packages/kobber-components/src/radio/radioInput/RadioInput.react.tsx
@@ -10,6 +10,7 @@ export const RadioInput = forwardRef<HTMLButtonElement & HTMLInputElement, Props
   const { checked, disabled, href, variant, children, ...rest } = props;
   const isLink = !!href;
   const role = isLink ? "" : "radio";
+  const tabIndex = checked ? 0 : -1;
 
   return (
     <>
@@ -22,7 +23,7 @@ export const RadioInput = forwardRef<HTMLButtonElement & HTMLInputElement, Props
         precedence="medium"
         dangerouslySetInnerHTML={{ __html: radioInputStyles.cssText }}
       ></style>
-      <InputTag {...rest} ref={ref} isLink={isLink} role={role}>
+      <InputTag {...rest} ref={ref} isLink={isLink} role={role} tabIndex={tabIndex}>
         <RadioInputControl checked={checked}></RadioInputControl>
         {children}
       </InputTag>

--- a/packages/kobber-components/src/radio/radioInput/RadioInput.react.tsx
+++ b/packages/kobber-components/src/radio/radioInput/RadioInput.react.tsx
@@ -9,6 +9,7 @@ type Props = InputProps & HTMLProps<HTMLButtonElement>;
 export const RadioInput = forwardRef<HTMLButtonElement & HTMLInputElement, Props>((props, ref) => {
   const { checked, disabled, href, variant, children, ...rest } = props;
   const isLink = !!href;
+  const role = isLink ? "" : "radio";
 
   return (
     <>
@@ -21,7 +22,7 @@ export const RadioInput = forwardRef<HTMLButtonElement & HTMLInputElement, Props
         precedence="medium"
         dangerouslySetInnerHTML={{ __html: radioInputStyles.cssText }}
       ></style>
-      <InputTag {...rest} ref={ref} isLink={isLink}>
+      <InputTag {...rest} ref={ref} isLink={isLink} role={role}>
         <RadioInputControl checked={checked}></RadioInputControl>
         {children}
       </InputTag>

--- a/packages/kobber-components/src/radio/radioInput/RadioInput.styles.react.ts
+++ b/packages/kobber-components/src/radio/radioInput/RadioInput.styles.react.ts
@@ -23,7 +23,8 @@ const createInputStyles = () => {
       justify-content: start;
       align-items: start;
       cursor: pointer;
-      padding: var(--kobber-component-input-selection-wrapper-padding);
+      padding: calc(var(--kobber-component-input-selection-wrapper-padding) + 0.15em)
+        var(--kobber-component-input-selection-wrapper-padding) var(--kobber-component-input-selection-wrapper-padding); /* A larger top padding emulates label being vertically aligned with idle input control, but not when multiple lines. */
 
       ${typographyButton()}
       ${buttonVariantStyles()}

--- a/packages/kobber-components/src/radio/radioInput/RadioInput.styles.react.ts
+++ b/packages/kobber-components/src/radio/radioInput/RadioInput.styles.react.ts
@@ -23,7 +23,7 @@ const createInputStyles = () => {
       justify-content: start;
       align-items: start;
       cursor: pointer;
-      padding-inline: var(${unsafeCSS(input.wrapper.padding)});
+      padding: var(--kobber-component-input-selection-wrapper-padding);
 
       ${typographyButton()}
       ${buttonVariantStyles()}

--- a/packages/kobber-components/src/radio/radioInput/RadioInput.styles.ts
+++ b/packages/kobber-components/src/radio/radioInput/RadioInput.styles.ts
@@ -25,7 +25,8 @@ const createInputStyles = () => {
       justify-content: start;
       align-items: start;
       cursor: pointer;
-      padding: var(${unsafeCSS(input.wrapper.padding)});
+      padding: calc(var(--kobber-component-input-selection-wrapper-padding) + 0.15em)
+        var(--kobber-component-input-selection-wrapper-padding) var(--kobber-component-input-selection-wrapper-padding); /* A larger top padding emulates label being vertically aligned with idle input control, but not when multiple lines. */
 
       ${typographyInput()}
       ${inputVariantStyles()}

--- a/packages/kobber-components/src/radio/radioInput/RadioInput.ts
+++ b/packages/kobber-components/src/radio/radioInput/RadioInput.ts
@@ -73,7 +73,9 @@ export class RadioInput extends ShoelaceElement implements InputProps {
   };
 
   private setInitialAttributes() {
-    this.setAttribute("role", "radio");
+    if (!this.isLink()) {
+      this.setAttribute("role", "radio");
+    }
     this.setAttribute("tabindex", "-1");
     this.setAttribute("aria-disabled", this.disabled ? "true" : "false");
   }

--- a/packages/kobber-components/src/radio/radioInputControl/RadioInputControl.react.tsx
+++ b/packages/kobber-components/src/radio/radioInputControl/RadioInputControl.react.tsx
@@ -8,6 +8,7 @@ import {
 } from "../Radio.core";
 import { radioInputControlStyles } from "./RadioInputControl.styles.react";
 import "../../base/styles/react.styles.css";
+import { InternalIconFormRadio } from "../../internal-icons/form-radio/index.react";
 
 type Props = ControlProps & HTMLProps<HTMLButtonElement>;
 
@@ -30,7 +31,9 @@ export const RadioInputControl = forwardRef<HTMLDivElement, Props>((props, ref) 
           radioInputControlPartName,
           checked ? radioInputControlPartNameChecked : "",
         ].join(" ")}
-      ></div>
+      >
+        <InternalIconFormRadio />
+      </div>
     </>
   );
 });

--- a/packages/kobber-components/src/radio/radioInputControl/RadioInputControl.styles.react.ts
+++ b/packages/kobber-components/src/radio/radioInputControl/RadioInputControl.styles.react.ts
@@ -11,12 +11,14 @@ const createInputControlStyles = () => {
   return css`
     .${unsafeCSS("kobber-radio-input-control" satisfies InputControlClassNames)} {
       --transition-time: 0.5s;
+      --icon-wrapper-height: var(${unsafeCSS(button.indicator.height)});
+      --icon-wrapper-width: var(${unsafeCSS(button.indicator.width)});
       --icon-height: var(${unsafeCSS(button.shape.height)});
       --icon-width: var(${unsafeCSS(button.shape.width)});
       box-sizing: content-box; /* Avoid vertical "shrinking" effect. */
       margin-top: 0.2em; /* Emulate vertical justification, but not when multiple lines.  */
-      width: var(--icon-width);
-      height: var(--icon-height);
+      width: var(--icon-wrapper-width);
+      height: var(--icon-wrapper-height);
       color: var(--control-color);
       border: var(${unsafeCSS(button.border.width)}) solid;
       outline: var(${unsafeCSS(button.outline.border.width)}) solid var(--control-outline-color);

--- a/packages/kobber-components/src/radio/radioInputControl/RadioInputControl.styles.react.ts
+++ b/packages/kobber-components/src/radio/radioInputControl/RadioInputControl.styles.react.ts
@@ -15,8 +15,7 @@ const createInputControlStyles = () => {
       --icon-wrapper-width: var(${unsafeCSS(button.indicator.width)});
       --icon-height: var(${unsafeCSS(button.shape.height)});
       --icon-width: var(${unsafeCSS(button.shape.width)});
-      box-sizing: content-box; /* Avoid vertical "shrinking" effect. */
-      margin-top: 0.2em; /* Emulate vertical justification, but not when multiple lines.  */
+      margin-top: 0.1em; /* A top margin emulates label being vertically aligned with idle input control, but not when multiple lines. */
       width: var(--icon-wrapper-width);
       height: var(--icon-wrapper-height);
       color: var(--control-color);
@@ -26,9 +25,6 @@ const createInputControlStyles = () => {
       transition: var(--transition-time) outline;
 
       ${buttonVariantStyles()}
-      &.${unsafeCSS("kobber-radio-input__control--checked" satisfies InputControlPartNames)} {
-        background-color: black;
-      }
     }
   `;
 };

--- a/packages/kobber-components/src/radio/radioInputControl/RadioInputControl.styles.ts
+++ b/packages/kobber-components/src/radio/radioInputControl/RadioInputControl.styles.ts
@@ -18,9 +18,7 @@ const createInputControlStyles = () => {
     }
 
     .${unsafeCSS("kobber-radio-input-control" satisfies InputControlClassNames)} {
-      box-sizing: content-box; /* Avoid vertical "shrinking" effect. */
-      margin-top: 0.2em; /* Emulate vertical justification, but not when multiple lines.  */
-
+      margin-top: 0.1em; /* A top margin emulates label being vertically aligned with idle input control, but not when multiple lines. */
       width: var(--icon-wrapper-width);
       height: var(--icon-wrapper-height);
       color: var(--control-color);

--- a/packages/kobber-components/src/radio/radioInputControl/RadioInputControl.styles.ts
+++ b/packages/kobber-components/src/radio/radioInputControl/RadioInputControl.styles.ts
@@ -11,6 +11,8 @@ const createInputControlStyles = () => {
   return css`
     :host {
       --transition-time: 0.5s;
+      --icon-wrapper-height: var(${unsafeCSS(button.indicator.height)});
+      --icon-wrapper-width: var(${unsafeCSS(button.indicator.width)});
       --icon-height: var(${unsafeCSS(button.shape.height)});
       --icon-width: var(${unsafeCSS(button.shape.width)});
     }
@@ -19,8 +21,8 @@ const createInputControlStyles = () => {
       box-sizing: content-box; /* Avoid vertical "shrinking" effect. */
       margin-top: 0.2em; /* Emulate vertical justification, but not when multiple lines.  */
 
-      width: var(--icon-width);
-      height: var(--icon-height);
+      width: var(--icon-wrapper-width);
+      height: var(--icon-wrapper-height);
       color: var(--control-color);
       border: var(${unsafeCSS(button.border.width)}) solid;
       outline: var(${unsafeCSS(button.outline.border.width)}) solid var(--control-outline-color);

--- a/packages/kobber-components/src/radio/radioInputControl/RadioInputControl.ts
+++ b/packages/kobber-components/src/radio/radioInputControl/RadioInputControl.ts
@@ -4,7 +4,7 @@ import ShoelaceElement from "../../base/internal/shoelace-element";
 import componentStyles from "../../base/styles/component.styles";
 import { radioInputControlStyles } from "./RadioInputControl.styles";
 import type { CSSResultGroup } from "lit";
-import "@gyldendal/kobber-icons/web-components";
+import "../../internal-icons/form-radio";
 import {
   InputVariant,
   radioInputControlPartNameChecked,


### PR DESCRIPTION
En rekke forbedringer etter tilbakemelding fra designer.

Så lenge de nye svg-ene var i flexbox fikk annenhver av dem ulik posisjonering i Safari. Trikset var å bruke dette på svg-wrapperen (istedet for flexbox): ` transform: translate(1px, 1px); `

Sammenligning før og etter (i Safari, dette innebærer altså mer enn bare transform-trikset):
![sammenligning](https://github.com/user-attachments/assets/0812856b-794e-4849-9092-434aa9859004)
