### PR TITLE
Make kobber-radio-group.react helpText optional

### DIFF
--- a/packages/kobber-components/src/radio/radioGroup/RadioGroup.react.tsx
+++ b/packages/kobber-components/src/radio/radioGroup/RadioGroup.react.tsx
@@ -4,7 +4,7 @@ import "../../button/Button.react";
 import { radioGroupStyles } from "./RadioGroup.styles";
 import "../../base/styles/react.styles.css";
 
-type Props = { helpText: string; children: Array<ReactElement> } & GroupProps;
+type Props = { helpText?: string; children: Array<ReactElement> } & GroupProps;
 
 export const RadioGroup = forwardRef<HTMLDivElement, Props>((props, ref) => {
   const { direction, helpText, label, children } = props;


### PR DESCRIPTION
It is handled as an optional prop in return statement, so it should be an actually optional prop.