### PR TITLE
docs: draft tools

### DIFF
--- a/apps/docs/app/(web)/fra-sanity/_draftTools/DarkModeTrigger.tsx
+++ b/apps/docs/app/(web)/fra-sanity/_draftTools/DarkModeTrigger.tsx
@@ -1,0 +1,29 @@
+"use client"
+
+import { useState } from "react"
+import { getCookieValue, setCookie } from "@/utils/clientCookies"
+import { KobberButton } from "@gyldendal/kobber-components/react-ssr-safe"
+import { Moon, Sun } from "lucide-react"
+
+export const DarkModeTrigger = () => {
+  const [colorScheme, setColorScheme] = useState(getCookieValue("color-scheme") ?? "default")
+  const oppositeMode = colorScheme === "dark" ? "default" : "dark"
+
+  const handleClick = () => {
+    setColorScheme(oppositeMode)
+    setCookie("color-scheme", oppositeMode)
+    window.location.reload()
+  }
+
+  const kobberTheme = `kobber-theme-${oppositeMode}`
+
+  return (
+    <KobberButton
+      variant="brand-primary-main"
+      className={kobberTheme}
+      icon={colorScheme === "dark" ? <Sun /> : <Moon />}
+      onClick={handleClick}
+      title={`Skru ${colorScheme === "dark" ? "av" : "på"} dark mode`}
+    />
+  )
+}

--- a/apps/docs/app/(web)/fra-sanity/_draftTools/DisableDraftMode.tsx
+++ b/apps/docs/app/(web)/fra-sanity/_draftTools/DisableDraftMode.tsx
@@ -1,5 +1,5 @@
-"use client"
-
+import { KobberButton } from "@gyldendal/kobber-components/react-ssr-safe"
+import { Edit } from "lucide-react"
 import { useDraftModeEnvironment } from "next-sanity/hooks"
 
 export function DisableDraftMode() {
@@ -11,8 +11,11 @@ export function DisableDraftMode() {
   }
 
   return (
-    <a href="/api/draft-mode/disable" className="fixed bottom-4 right-4 bg-gray-50 px-4 py-2">
-      Skru av redigeringsmodus
-    </a>
+    <KobberButton
+      variant="brand-primary-main"
+      href="/api/draft-mode/disable"
+      icon={<Edit />}
+      title="Skru av draft mode"
+    />
   )
 }

--- a/apps/docs/app/(web)/fra-sanity/_draftTools/DraftTools.module.css
+++ b/apps/docs/app/(web)/fra-sanity/_draftTools/DraftTools.module.css
@@ -1,0 +1,10 @@
+.panel {
+  position: fixed;
+  bottom: 0;
+  right: 0;
+  z-index: 9999;
+  padding: 1rem;
+
+  display: flex;
+  gap: 0.5rem;
+}

--- a/apps/docs/app/(web)/fra-sanity/_draftTools/DraftTools.tsx
+++ b/apps/docs/app/(web)/fra-sanity/_draftTools/DraftTools.tsx
@@ -1,0 +1,67 @@
+"use client"
+
+import { useState } from "react"
+import { KobberButton } from "@gyldendal/kobber-components/react-ssr-safe"
+import { Settings } from "@gyldendal/kobber-icons/react-ssr-safe"
+import { VisualEditing } from "next-sanity"
+import { DarkModeTrigger } from "./DarkModeTrigger"
+import { DisableDraftMode } from "./DisableDraftMode"
+import styles from "./DraftTools.module.css"
+import { TokenMixer } from "./TokenMixer"
+
+export const DraftTools = () => {
+  const [open, setOpen] = useState(false)
+  return (
+    <>
+      <div className={styles["panel"]}>
+        {open && (
+          <>
+            <DisableDraftMode />
+            <DarkModeTrigger />
+            <TokenMixer />
+            <KobberButton
+              variant="vacation-primary-main"
+              icon={<SanityLogo />}
+              title="Åpne studio"
+              href="/studio"
+            />
+          </>
+        )}
+
+        <KobberButton
+          className={styles["trigger"]}
+          variant="brand-secondary-main"
+          icon={<Settings />}
+          onClick={() => setOpen(!open)}
+          title={`${open ? "Lukk" : "Åpne"} draft tools`}
+        />
+      </div>
+
+      <VisualEditing />
+    </>
+  )
+}
+
+const SanityLogo = () => (
+  <svg
+    width="100%"
+    height="100%"
+    viewBox="0 0 33 33"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <rect width="100%" height="100%"></rect>
+    <path
+      d="M10.1637 8.5498C10.1637 11.3854 11.9461 13.0725 15.5143 13.9622L19.2955 14.8235C22.6725 15.5855 24.729 17.4783 24.729 20.5619C24.7553 21.9053 24.3107 23.2168 23.4698 24.2765C23.4698 21.1999 21.8499 19.5376 17.9425 18.538L14.2299 17.7086C11.257 17.0423 8.9623 15.4863 8.9623 12.1368C8.94666 10.8433 9.36932 9.58143 10.1637 8.5498Z"
+      fill="white"
+    ></path>
+    <path
+      d="M21.1463 19.8069C22.7591 20.8206 23.4662 22.2384 23.4662 24.2729C22.1313 25.953 19.7861 26.8958 17.0297 26.8958C12.3899 26.8958 9.1427 24.6521 8.42111 20.7533H12.8769C13.4506 22.5432 14.9695 23.3726 16.9972 23.3726C19.4722 23.3726 21.1175 22.0753 21.1499 19.7998"
+      fill="#F8B1AA"
+    ></path>
+    <path
+      d="M12.4801 12.7536C11.7436 12.3236 11.1394 11.7057 10.7316 10.9656C10.3238 10.2255 10.1276 9.3907 10.1638 8.54984C11.4518 6.88396 13.6923 5.8667 16.4235 5.8667C21.1499 5.8667 23.8848 8.31945 24.5595 11.7717H20.2732C19.8006 10.4107 18.6172 9.35089 16.4596 9.35089C14.1541 9.35089 12.5811 10.6694 12.4909 12.7536"
+      fill="#F8B1AA"
+    ></path>
+  </svg>
+)

--- a/apps/docs/app/(web)/fra-sanity/_draftTools/TokenMixer.tsx
+++ b/apps/docs/app/(web)/fra-sanity/_draftTools/TokenMixer.tsx
@@ -1,0 +1,86 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { KobberButton } from "@gyldendal/kobber-components/react-ssr-safe"
+import { Settings2Icon } from "lucide-react"
+
+export const TokenMixer = () => {
+  const [show, setShow] = useState(false)
+  const handleClick = () => {
+    setShow((prev) => !prev)
+  }
+  return (
+    <>
+      {show && <TokenOverlay onClose={() => setShow(false)} />}
+      <KobberButton
+        variant="brand-primary-main"
+        icon={<Settings2Icon />}
+        title="Token mixer"
+        onClick={handleClick}
+      />
+    </>
+  )
+}
+
+const TokenOverlay = ({ onClose }: { onClose: () => void }) => {
+  const [defaultCss, setDefaultCss] = useState("")
+  const [localCss, setLocalCss] = useState(sessionStorage.getItem("tokenMixerCss"))
+
+  useEffect(() => {
+    fetch("https://esm.sh/@gyldendal/kobber-base/themes/default/tokens.css")
+      .then((response) => {
+        if (!response.ok) {
+          throw new Error(`HTTP error! status: ${response.status}`)
+        }
+        return response.text()
+      })
+      .then((cssText) => {
+        setDefaultCss(cssText)
+      })
+      .catch((error) => {
+        console.error("Failed to fetch CSS file:", error)
+      })
+  }, [])
+
+  const handleSaveCss = () => {
+    if (localCss) sessionStorage.setItem("tokenMixerCss", localCss)
+  }
+
+  const handleResetCss = () => {
+    sessionStorage.removeItem("tokenMixerCss")
+    setLocalCss(defaultCss)
+  }
+
+  return (
+    <>
+      <style href={"token-mixer" + new Date().toISOString()} precedence="medium">
+        {localCss || defaultCss}
+      </style>
+      <div className="fixed inset-[10vw] flex flex-col items-center justify-center gap-4 rounded-lg bg-white p-4 shadow-lg">
+        <div className="text-center">
+          <h2 className="text-2xl font-bold">Token mixer</h2>
+          <small className="text-gray-500">
+            Endre design tokens live på siden. Trykk save for å huske innstillingene når du lukker
+            modalen.
+          </small>
+        </div>
+        <textarea
+          className="size-full resize-none rounded-lg border-2 border-gray-300 p-4 font-mono"
+          value={localCss || defaultCss}
+          onChange={(e) => setLocalCss(e.target.value)}
+        />
+        <div className="flex gap-4">
+          <KobberButton variant="brand-primary-main" onClick={handleSaveCss}>
+            Save
+          </KobberButton>
+          <KobberButton variant="brand-secondary-main" onClick={handleResetCss}>
+            Reset
+          </KobberButton>
+          <KobberButton variant="brand-tertiary-main" onClick={onClose}>
+            Close
+          </KobberButton>
+        </div>
+      </div>
+    </>
+  )
+}

--- a/apps/docs/app/(web)/fra-sanity/layout.tsx
+++ b/apps/docs/app/(web)/fra-sanity/layout.tsx
@@ -1,8 +1,7 @@
 import { draftMode } from "next/headers"
 import { SanityLive } from "@/sanity/lib/live"
-import { VisualEditing } from "next-sanity"
 import { cn } from "@/lib/utils"
-import { DisableDraftMode } from "@/components/DisableDraftMode"
+import { DraftTools } from "./_draftTools/DraftTools"
 
 export default async function RootLayout({ children }: React.PropsWithChildren) {
   const draft = await draftMode()
@@ -11,12 +10,7 @@ export default async function RootLayout({ children }: React.PropsWithChildren) 
     <div className={cn("sanity-layout")}>
       {children}
       <SanityLive />
-      {(await draftMode()).isEnabled && (
-        <>
-          <DisableDraftMode />
-          <VisualEditing />
-        </>
-      )}
+      {(await draftMode()).isEnabled && <DraftTools />}
     </div>
   )
 }

--- a/apps/docs/utils/clientCookies.ts
+++ b/apps/docs/utils/clientCookies.ts
@@ -1,0 +1,9 @@
+export const setCookie = (name: string, value: string) => {
+  document.cookie = name + "=" + value + ";Path=/"
+}
+
+export const getCookieValue = (name: string) =>
+  document.cookie
+    .split(";")
+    .find((row) => row.startsWith(name))
+    ?.split("=")[1]


### PR DESCRIPTION
Testing tools for the docs page easily accessible from a button panel bottom right. Only visible in NextJS draft mode.

One of the tools is a way to easily change tokens live on the docs page:

![image](https://github.com/user-attachments/assets/a91e4ae5-f12d-4c11-8403-579288be6957)
