### PR TITLE
Added init function

### DIFF
--- a/packages/kobber-components/README.md
+++ b/packages/kobber-components/README.md
@@ -79,6 +79,22 @@ const progressBar = new ProgressBar();
 document.body.appendChild(progressBar);
 ```
 
+## Auto-registering web components
+
+To make the web components render they need to be registered:
+
+```js
+window.customElements.define("kobber-button", KobberButton);
+```
+
+This can be done automatically using the `init`-function:
+
+```js
+import { init } from "@gyldendal/kobber-components/init";
+
+init({ autoRegisterWebComponents: true });
+```
+
 ## CSS
 
 We recommend using [normalize.css](https://github.com/necolas/normalize.css/) or something similar to normalize browser styles.

--- a/packages/kobber-components/package.json
+++ b/packages/kobber-components/package.json
@@ -14,7 +14,8 @@
     ],
     "./vanilla/*.css": [
       "./dist/vanilla/*.css"
-    ]
+    ],
+    "./init/": "./dist/init/index.js"
   },
   "scripts": {
     "clean": "rm -rf .turbo node_modules dist",

--- a/packages/kobber-components/src/base/config.ts
+++ b/packages/kobber-components/src/base/config.ts
@@ -1,0 +1,15 @@
+export interface Config {
+  autoRegisterWebComponents: boolean;
+}
+
+const defaultConfig: Config = {
+  autoRegisterWebComponents: true,
+};
+
+let resolveConfig: (config: Config) => void;
+
+const promise = new Promise<Config>(resolve => (resolveConfig = resolve));
+
+export const setConfig = (config: Config = defaultConfig) => resolveConfig(config);
+
+export const getConfig = () => promise;

--- a/packages/kobber-components/src/base/init.ts
+++ b/packages/kobber-components/src/base/init.ts
@@ -1,0 +1,3 @@
+import { Config, setConfig } from "./config";
+
+export const init = (config?: Config) => setConfig(config);

--- a/packages/kobber-components/src/base/utilities/customElementDecorator.ts
+++ b/packages/kobber-components/src/base/utilities/customElementDecorator.ts
@@ -7,22 +7,43 @@
 // This decorator prevents browsers and node.js from crashing if a custom element is already defined.
 
 import type { CustomElementDecorator } from "lit/decorators.js";
+import { getConfig } from "../config";
 
 type CustomElementClass = Omit<typeof HTMLElement, "new">;
 
 export const customElement =
   (tagName: string): CustomElementDecorator =>
   (classOrTarget: CustomElementClass, context?: ClassDecoratorContext) => {
-    const existing = customElements.get(tagName);
-    if (existing) {
-      console.warn(`The element ${tagName} is already defined. You may need to reload to see changes.`);
-    } else {
-      if (context !== undefined) {
-        context.addInitializer(() => {
-          customElements.define(tagName, classOrTarget as CustomElementConstructor);
-        });
-      } else {
-        customElements.define(tagName, classOrTarget as CustomElementConstructor);
-      }
-    }
+    runDecorator({
+      tagName,
+      classOrTarget,
+      context,
+    });
   };
+
+interface DecoratorArgs {
+  tagName: string;
+  classOrTarget: CustomElementClass;
+  context?: ClassDecoratorContext;
+}
+
+const runDecorator = async (decoratorArgs: DecoratorArgs) => {
+  const config = await getConfig();
+  if (!config.autoRegisterWebComponents) return;
+  register(decoratorArgs);
+};
+
+const register = ({ tagName, classOrTarget, context }: DecoratorArgs) => {
+  const existing = customElements.get(tagName);
+  if (existing) {
+    console.warn(`The element ${tagName} is already defined. You may need to reload to see changes.`);
+  } else {
+    if (context !== undefined) {
+      context.addInitializer(() => {
+        customElements.define(tagName, classOrTarget as CustomElementConstructor);
+      });
+    } else {
+      customElements.define(tagName, classOrTarget as CustomElementConstructor);
+    }
+  }
+};

--- a/packages/kobber-components/tsup.config.ts
+++ b/packages/kobber-components/tsup.config.ts
@@ -16,6 +16,7 @@ listReactComponents(`./src/${reactListFile}`, componentObjects);
 
 export default defineConfig(() => ({
   entry: {
+    ["init/index"]: "src/base/init.ts",
     [`${reactDirectory}/index`]: `src/${reactListFile}`,
     [`${webComponentsDirectory}/index`]: `src/${webComponentListFile}`,
   },

--- a/packages/kobber-icons/README.md
+++ b/packages/kobber-icons/README.md
@@ -41,6 +41,22 @@ const App = () => <ArrowRight />;
 <kobber-arrow_right />
 ```
 
+##### Auto-registering web components
+
+To make the web components render they need to be registered:
+
+```js
+window.customElements.define("kobber-add_figure", AddFigure);
+```
+
+This can be done automatically using the `init`-function:
+
+```js
+import { init } from "@gyldendal/kobber-icons/init";
+
+init({ autoRegisterWebComponents: true });
+```
+
 Custom element icon names are prefixed with kobber-, to ensure [valid naming](https://html.spec.whatwg.org/multipage/custom-elements.html#valid-custom-element-name).
 
 #### Use sprite directly

--- a/packages/kobber-icons/package.json
+++ b/packages/kobber-icons/package.json
@@ -12,7 +12,8 @@
     "./web-components": "./dist/web-components/index.js",
     "./symbols": [
       "./dist/symbols/*.*"
-    ]
+    ],
+    "./init/": "./dist/init/index.js"
   },
   "scripts": {
     "clean": "rm -rf .turbo node_modules dist src/tmp",

--- a/packages/kobber-icons/src/base/config.ts
+++ b/packages/kobber-icons/src/base/config.ts
@@ -1,0 +1,15 @@
+export interface Config {
+  autoRegisterWebComponents: boolean;
+}
+
+const defaultConfig: Config = {
+  autoRegisterWebComponents: true,
+};
+
+let resolveConfig: (config: Config) => void;
+
+const promise = new Promise<Config>(resolve => (resolveConfig = resolve));
+
+export const setConfig = (config: Config = defaultConfig) => resolveConfig(config);
+
+export const getConfig = () => promise;

--- a/packages/kobber-icons/src/base/init.ts
+++ b/packages/kobber-icons/src/base/init.ts
@@ -1,0 +1,3 @@
+import { Config, setConfig } from "./config";
+
+export const init = (config?: Config) => setConfig(config);

--- a/packages/kobber-icons/tsup-scripts/make-web-component.ts
+++ b/packages/kobber-icons/tsup-scripts/make-web-component.ts
@@ -5,6 +5,7 @@ export const makeWebComponent = (symbol: SVGSymbolElement) => {
 
   const preamble = `import * as tokens from "@gyldendal/kobber-base/themes/default/tokens.js";
 import { SizeType } from "../../types/kobber-icons-types";
+import { getConfig } from "../../../base/config";
 
 `;
 
@@ -53,9 +54,15 @@ import { SizeType } from "../../types/kobber-icons-types";
 
 export const customElementName = "${symbol.id}";
 
-if (!customElements.get(customElementName)) {
-  customElements.define(customElementName, ${iconNames.unprefixedCapitalized});
-}
+const register = async () => {
+  const config = await getConfig();
+  if (!config.autoRegisterWebComponents) return;
+  if (!customElements.get(customElementName)) {
+    customElements.define(customElementName, ${iconNames.unprefixedCapitalized});
+  }
+};
+
+register();
 `;
 
   return componentCode;

--- a/packages/kobber-icons/tsup.config.ts
+++ b/packages/kobber-icons/tsup.config.ts
@@ -32,6 +32,7 @@ listComponents(symbols);
 
 export default defineConfig(() => ({
   entry: {
+    ["init/index"]: "src/base/init.ts",
     [`${reactDirectory}/index`]: "src/index.react.tsx",
     [`${reactSsrSafeDirectory}/index`]: "src/index.react-ssr-safe.tsx",
     [`${webComponentsDirectory}/index`]: "src/index.web-components.ts",


### PR DESCRIPTION
Web components do no longer register automatically. To register all components:

```
import { init } from "@gyldendal/kobber-components/init";
init({ autoRegisterWebComponents: true });
```