### PR TITLE
Correct spacing between "paragraphs"

### DIFF
--- a/apps/docs/styles/globals.css
+++ b/apps/docs/styles/globals.css
@@ -50,7 +50,11 @@
     overflow: hidden;
   }
 
-  p:last-of-type {
+  /* Make spacing between paragraphs (that are not structured as paragraphs) */
+  p:last-of-type:not(:has(~ *)),
+  ul:last-of-type:not(:has(~ *)),
+  ol:last-of-type:not(:has(~ *)),
+  img:last-of-type:not(:has(~ *)) {
     margin-bottom: 4.5em;
   }
 }


### PR DESCRIPTION
Paragraphs in our usage of Sanity is not structured as paragraphs. Therefore, spacing between them is made as "margin-bottom after last element".