### PR TITLE
Add checkbox group

### DIFF
--- a/packages/kobber-components/src/checkbox/Checkbox.core.ts
+++ b/packages/kobber-components/src/checkbox/Checkbox.core.ts
@@ -1,7 +1,7 @@
 import { component } from "@gyldendal/kobber-base/themes/default/tokens.js";
 
 export const checkboxWrapperClassName = "kobber-checkbox-wrapper";
-export const checkboxInputName = "kobber-checkbox";
+export const checkboxInputName = "kobber-checkbox-input";
 export const nativeCheckboxInputClassName = "native-input";
 export const checkboxLabelClassName = "kobber-checkbox__label";
 export const checkboxControlClassName = "kobber-checkbox__control";

--- a/packages/kobber-components/src/checkbox/Checkbox.core.ts
+++ b/packages/kobber-components/src/checkbox/Checkbox.core.ts
@@ -1,15 +1,29 @@
 import { component } from "@gyldendal/kobber-base/themes/default/tokens.js";
 
+export const checkboxGroupName = "kobber-checkbox-group";
 export const checkboxWrapperClassName = "kobber-checkbox-wrapper";
 export const checkboxInputName = "kobber-checkbox-input";
 export const nativeCheckboxInputClassName = "native-input";
 export const checkboxLabelClassName = "kobber-checkbox__label";
 export const checkboxControlClassName = "kobber-checkbox__control";
+export const checkboxGroupHorizontalClassName = "kobber-checkbox-group--horizontal";
+export const checkboxIconClassName = "kobber-checkbox__control--shape";
+
+export type CheckboxIconClassNames = typeof checkboxIconClassName;
 
 export const checkboxInputClassNames = ({ state = "idle" }: InputProps): CheckboxClassNames[] => {
   const conditionalClassNames: CheckboxClassNames[] = [];
 
   return [checkboxInputName, state, ...conditionalClassNames];
+};
+
+export type GroupProps = {
+  direction?: "vertical" | "horizontal";
+  form?: string;
+  label?: string;
+  name?: string;
+  required?: boolean;
+  value?: string;
 };
 
 export type InputProps = {
@@ -27,6 +41,7 @@ export type InputProps = {
   variant?: CheckboxVariant;
 };
 
+export type GroupClassNames = typeof checkboxGroupName;
 export type WrapperClassName = typeof checkboxWrapperClassName;
 export type CheckboxClassNames = typeof checkboxInputName | CheckboxState;
 export type NativeInputClassName = typeof nativeCheckboxInputClassName;

--- a/packages/kobber-components/src/checkbox/Checkbox.mdx
+++ b/packages/kobber-components/src/checkbox/Checkbox.mdx
@@ -5,9 +5,17 @@ import "storybook-web-components/public/global.css";
 
 <Meta of={CheckboxStories} />
 
-# Checkbox Inputs
+# Checkbox Group and Inputs
+
+Use Checkbox Inputs to select one or more options from a list of choices. Checkbox Input may be used inside a Checkbox Group, or separately.
+
+A Checkbox Group contains more than one Checkbox Input, but the Checkbox Inputs are not mutually exclusive.
+
+When used separately, Checkbox Inputs should specify name. When used in a Checkbox Group, name is specified on the group.
 
 Use Checkbox Inputs to select one or more options from a list of choices.
+
+Keyboard navigation: Use tab to reach the Checkbox group, and <a href="https://www.w3.org/WAI/ARIA/apg/practices/keyboard-interface/#:~:text=A%20primary%20keyboard,multiple%20focusable%20elements.">arrow keys</a> to move focus inside the group.
 
 <details>
   <summary>Not implemented: Validation</summary>

--- a/packages/kobber-components/src/checkbox/Checkbox.stories.ts
+++ b/packages/kobber-components/src/checkbox/Checkbox.stories.ts
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/web-components";
 import "./checkbox-input/CheckboxInput";
+import "./checkbox-group/CheckboxGroup";
 import "../theme-context-provider/ThemeContext";
 import { InputProps, CheckboxState, checkboxVariants } from "./Checkbox.core";
 import { init as initComponents } from "../base/init";
@@ -164,8 +165,8 @@ export const Checkbox: Story = {
         variant="success" 
         ${args.disabled ? "disabled" : ""}
         ${args.checked}
-        id="studentoption"
-        value="totalpoints"
+        name="studentoption"
+        id-value="totalpoints"
       >
         <span>Vis ukas totalpoeng</span>
         ${args.showHelpText ? `<span slot="help-text" style="font-style: italic;color:gray;">Læreren din har skrudd ${args.disabled ? "av" : "på"} denne innstillingen.</span>` : ""}
@@ -184,5 +185,60 @@ export const Checkbox: Story = {
     disabled: false,
     showHelpText: true,
     showAlert: true,
+  },
+};
+
+export const GNOExample: Story = {
+  render: args => {
+    return `
+      <style>
+        :root {
+          padding: 0.5rem;
+        }
+        .wrapper-theme {
+          display: flex;
+          flex-direction: column;
+          gap: 3rem;
+        }
+        .visually-hidden {
+          position: absolute;
+          width: 1px;
+          height: 1px;
+          padding: 0;
+          margin: -1px;
+          overflow: hidden;
+          clip: rect(0, 0, 0, 0);
+          white-space: nowrap;
+          border: 0;
+        }
+      </style>
+
+      <div class="wrapper-theme">
+        <kobber-checkbox-group name="categories" orientation="${args.orientation}" type="${args.type}" hierarchical-checkboxbox-label="Alle">
+          <p slot="label">Kategori</p>
+          <kobber-checkbox-input id-value="fiction">Skjønnlitteratur</kobber-checkbox-input>
+          <kobber-checkbox-input id-value="non-fiction" disabled>Sakprosa</kobber-checkbox-input>
+          <kobber-checkbox-input id-value="childrens-books">Barnebøker</kobber-checkbox-input>
+          <kobber-checkbox-input id-value="syllabi">Pensumbøker</kobber-checkbox-input>
+          <kobber-checkbox-input id-value="professional">Profesjonsbøker</kobber-checkbox-input>
+        ${args.showGroupHelpText ? `<span slot="help-text">Velg noe, da.</span>` : ""}
+        </kobber-checkbox-group>
+      </div>
+    `;
+  },
+  args: {
+    showGroupHelpText: true,
+    type: "hierarchical",
+    orientation: "vertical",
+  },
+  argTypes: {
+    orientation: {
+      control: "inline-radio",
+      options: ["horisontal", "vertical"],
+    },
+    type: {
+      control: "inline-radio",
+      options: ["equal", "hierarchical"],
+    },
   },
 };

--- a/packages/kobber-components/src/checkbox/Checkbox.stories.ts
+++ b/packages/kobber-components/src/checkbox/Checkbox.stories.ts
@@ -142,7 +142,7 @@ const renderButton = (
   const className = `${focus} ${state}`;
   const lastStyles = last ? `grid-column: -1` : "";
   return `
-    <kobber-checkbox
+    <kobber-checkbox-input
       style="${lastStyles}"
       class="${className}"
       variant="${variant}"
@@ -150,7 +150,7 @@ const renderButton = (
       ${state === "disabled" ? "disabled" : ""}
     >
       ${text}
-    </kobber-checkbox>
+    </kobber-checkbox-input>
   `;
 };
 
@@ -160,7 +160,7 @@ const renderButton = (
 export const Checkbox: Story = {
   render: args => {
     return `
-      <kobber-checkbox 
+      <kobber-checkbox-input 
         variant="success" 
         ${args.disabled ? "disabled" : ""}
         ${args.checked}
@@ -170,7 +170,7 @@ export const Checkbox: Story = {
         <span>Vis ukas totalpoeng</span>
         ${args.showHelpText ? `<span slot="help-text" style="font-style: italic;color:gray;">Læreren din har skrudd ${args.disabled ? "av" : "på"} denne innstillingen.</span>` : ""}
         ${args.showAlert ? `<div slot="alert" style="background-color:#CBFBDB;padding: 0.5em;border-radius:0.5em;"><p class="badge">TODO: Use badge component.</p></div>` : ""}
-      </kobber-checkbox>
+      </kobber-checkbox-input>
     `;
   },
   argTypes: {

--- a/packages/kobber-components/src/checkbox/checkbox-group/CheckboxGroup.styles.ts
+++ b/packages/kobber-components/src/checkbox/checkbox-group/CheckboxGroup.styles.ts
@@ -1,0 +1,38 @@
+import { css, unsafeCSS } from "lit";
+import { GroupClassNames } from "../Checkbox.core";
+import { component } from "@gyldendal/kobber-base/themes/default/tokens.css-variables.js";
+
+/**
+ * Shared styles, used in web component, React and CSS module.
+ *
+ */
+const createCheckboxGroupStyles = () => {
+  return css`
+    .${unsafeCSS("kobber-checkbox-group" satisfies GroupClassNames)} {
+      display: flex;
+      flex-direction: column;
+      padding: 0;
+      /* TOOD: Use real tokens when available: */
+      gap: var(--checkbox-group-input-container-gap, 4px);
+      border: none;
+    }
+    .default-slot {
+      display: flex;
+      flex-wrap: wrap;
+
+      [data-orientation="vertical"] & {
+        flex-direction: column;
+        gap: var(--checkbox-group-inner-input-container-gap, 4px);
+        [data-type="hierarchical"] & {
+          padding-left: var(--checkbox-group-inner-input-container-padding-left, 16px);
+        }
+      }
+      [data-orientation="horisontal"] & {
+        gap: 0 16px;
+      }
+    }
+    /* /TOOD */
+  `;
+};
+
+export const checkboxGroupStyles = createCheckboxGroupStyles();

--- a/packages/kobber-components/src/checkbox/checkbox-group/CheckboxGroup.ts
+++ b/packages/kobber-components/src/checkbox/checkbox-group/CheckboxGroup.ts
@@ -1,0 +1,256 @@
+import { html, unsafeStatic } from "lit/static-html.js";
+import type { CSSResultGroup } from "lit";
+import { customElement, property, query, state } from "lit/decorators.js";
+import ShoelaceElement from "../../base/internal/shoelace-element";
+import { HasSlotController } from "../../base/internal/slot";
+import type { ShoelaceFormControl } from "../../base/internal/shoelace-element";
+import {
+  customErrorValidityState,
+  FormControlController,
+  validValidityState,
+  valueMissingValidityState,
+} from "../../base/internal/form";
+import componentStyles from "../../base/styles/component.styles";
+import type { CheckboxInput } from "../checkbox-input/CheckboxInput";
+import { checkboxGroupName, checkboxInputName, GroupProps } from "../Checkbox.core";
+import { checkboxGroupStyles } from "./CheckboxGroup.styles";
+
+/**
+ * @summary Checkbox groups are used to group multiple [checkboxes](/components/checkbox).
+ * @status stable
+ * @since 2.0
+ *
+ * @slot - The default slot where `<kobber-checkbox-button>` elements are placed.
+ * @slot label - The checkbox group's label. Required for proper accessibility. Alternatively, you can use the `label`
+ *  attribute.
+ * @slot help-text - Text that describes how to use the checkbox group. Alternatively, you can use the `help-text` attribute.
+ *
+ */
+
+type Props = GroupProps & ShoelaceFormControl;
+
+@customElement(checkboxGroupName)
+export class CheckboxGroup extends ShoelaceElement implements Props {
+  disabled?: boolean | undefined;
+  defaultChecked?: boolean | undefined;
+  input!: HTMLInputElement;
+  validationMessage: string = "";
+
+  static styles: CSSResultGroup = [componentStyles, checkboxGroupStyles];
+
+  protected readonly formControlController = new FormControlController(this);
+  private readonly hasSlotController = new HasSlotController(this, "help-text", "label");
+  private customValidityMessage = "";
+
+  @query("slot:not([name])") defaultSlot!: HTMLSlotElement;
+
+  @property() type: "equal" | "hierarchical" = "equal";
+  @property({ attribute: "hierarchical-checkboxbox-label" }) hierarchicalCheckboxLabel = "";
+
+  /**
+   * The checkbox group's label. Required for proper accessibility. If you need to display HTML, use the `label` slot
+   * instead.
+   */
+  @property() label = "";
+
+  /** The name of the checkbox group, submitted as a name/value pair with form data. */
+  @property() name = "option";
+
+  @property() orientation: "vertical" | "horizontal" = "vertical";
+
+  /** The current value of the checkbox group, submitted as a name/value pair with form data. */
+  @state() private idValues: string[] = [];
+
+  @state() private allBoxesAreChecked = false;
+  @state() private hierarchicalCheckboxIsChecked = false;
+  @state() private someButNotAllBoxesAreChecked = false;
+
+  /**
+   * By default, form controls are associated with the nearest containing `<form>` element. This attribute allows you
+   * to place the form control outside of a form and associate it with the form that has this `id`. The form must be in
+   * the same document or shadow root for this to work.
+   */
+  @property({ reflect: true }) form = "";
+
+  /** Ensures a child checkbox is checked before allowing the containing form to submit. */
+  @property({ type: Boolean, reflect: true }) required = false;
+
+  /** Gets the validity state object */
+  get validity() {
+    const isRequiredAndEmpty = this.required && !this.idValues;
+    const hasCustomValidityMessage = this.customValidityMessage !== "";
+
+    if (hasCustomValidityMessage) {
+      return customErrorValidityState;
+    } else if (isRequiredAndEmpty) {
+      return valueMissingValidityState;
+    }
+
+    return validValidityState;
+  }
+
+  constructor() {
+    super();
+  }
+  direction?: "vertical" | "horizontal" | undefined;
+  value: string | undefined;
+  defaultValue?: unknown;
+  pattern?: string | undefined;
+  min?: string | number | Date | undefined;
+  max?: string | number | Date | undefined;
+  step?: number | "any" | undefined;
+  minlength?: number | undefined;
+  maxlength?: number | undefined;
+  checked?: boolean | undefined;
+  indeterminate?: boolean | undefined;
+
+  connectedCallback() {
+    super.connectedCallback();
+  }
+
+  firstUpdated() {
+    this.formControlController.updateValidity();
+  }
+
+  private getAllCheckboxes() {
+    return [...this.querySelectorAll<CheckboxInput>(checkboxInputName)];
+  }
+
+  /**
+   * Populate name/value pairs array?
+   */
+  private async syncCheckboxElements() {
+    const checkboxes = this.getAllCheckboxes();
+    const numberOfNotDisabledCheckboxes = checkboxes.filter(box => !box.disabled).length;
+
+    await Promise.all(
+      // Sync the checked state and size
+      checkboxes.map(async checkbox => {
+        await checkbox.updateComplete;
+
+        const index = this.idValues.findIndex(item => item === checkbox.idValue);
+        if (checkbox.checked) {
+          if (index < 0) {
+            this.idValues.push(checkbox.idValue as string);
+          }
+        } else if (index > -1) {
+          this.idValues.splice(index, 1);
+        }
+      }),
+    );
+
+    if (this.idValues.length > 0) {
+      if (numberOfNotDisabledCheckboxes === this.idValues.length) {
+        this.allBoxesAreChecked = true;
+        this.someButNotAllBoxesAreChecked = false;
+      } else {
+        this.allBoxesAreChecked = false;
+        this.someButNotAllBoxesAreChecked = true;
+      }
+    } else {
+      this.allBoxesAreChecked = false;
+      this.someButNotAllBoxesAreChecked = false;
+    }
+  }
+
+  private syncCheckboxes() {
+    if (customElements.get(checkboxInputName)) {
+      this.syncCheckboxElements();
+      return;
+    }
+
+    if (customElements.get(checkboxInputName)) {
+      this.syncCheckboxElements();
+    } else {
+      customElements.whenDefined(checkboxInputName).then(() => this.syncCheckboxes());
+    }
+  }
+
+  /** Checks for validity but does not show a validation message. Returns `true` when valid and `false` when invalid. */
+  checkValidity() {
+    const isRequiredAndEmpty = this.required && !this.idValues;
+    const hasCustomValidityMessage = this.customValidityMessage !== "";
+
+    if (isRequiredAndEmpty || hasCustomValidityMessage) {
+      this.formControlController.emitInvalidEvent();
+      return false;
+    }
+
+    return true;
+  }
+
+  /** Gets the associated form, if one exists. */
+  getForm(): HTMLFormElement | null {
+    return this.formControlController.getForm();
+  }
+
+  /** Checks for validity and shows the browser's validation message if the control is invalid. */
+  reportValidity(): boolean {
+    const isValid = this.validity.valid;
+
+    this.formControlController.setValidity(isValid);
+
+    return isValid;
+  }
+
+  /** Sets a custom validation message. Pass an empty string to restore validity. */
+  setCustomValidity(message = "") {
+    this.customValidityMessage = message;
+    this.formControlController.updateValidity();
+  }
+
+  private async handleHierarchicalCheckboxClick(e: Event) {
+    e.preventDefault(); // Avoid emitting two clicks
+    this.hierarchicalCheckboxIsChecked = !this.hierarchicalCheckboxIsChecked;
+
+    const checkboxes = this.getAllCheckboxes();
+    await Promise.all(
+      // Sync the checked state and size
+      checkboxes.map(async checkbox => {
+        await checkbox.updateComplete;
+        if (!checkbox.disabled) {
+          checkbox.checked = this.hierarchicalCheckboxIsChecked;
+        }
+      }),
+    );
+    this.syncCheckboxElements();
+  }
+
+  render() {
+    const hasHelpTextSlot = this.hasSlotController.test("help-text");
+    const hasHelpText = !!hasHelpTextSlot;
+    const isHierarchical = this.type == "hierarchical";
+    const hierarchicalCheckbox = isHierarchical
+      ? html`<${unsafeStatic(checkboxInputName)}
+        .checked=${this.allBoxesAreChecked} 
+        .indeterminate=${this.someButNotAllBoxesAreChecked}
+        @click=${this.handleHierarchicalCheckboxClick}
+        >
+          ${this.hierarchicalCheckboxLabel}
+        </${unsafeStatic(checkboxInputName)}>`
+      : "";
+    const defaultSlot = html`
+      <slot class="default-slot" @slotchange=${this.syncCheckboxes} @click=${this.syncCheckboxes}></slot>
+    `;
+
+    return html`
+      <fieldset
+        class="${checkboxGroupName}"
+        data-orientation="${this.orientation}"
+        data-type="${this.type}"
+        aria-describedby="aria-help-text"
+        aria-errormessage="error-message"
+      >
+        <legend>
+          <slot name="label">${this.label}</slot>
+        </legend>
+
+        ${hierarchicalCheckbox} ${defaultSlot}
+
+        <div id="aria-help-text" aria-hidden=${hasHelpText ? "false" : "true"}>
+          <slot name="help-text"></slot>
+        </div>
+      </fieldset>
+    `;
+  }
+}

--- a/packages/kobber-components/src/checkbox/checkbox-input/CheckboxInput.ts
+++ b/packages/kobber-components/src/checkbox/checkbox-input/CheckboxInput.ts
@@ -1,4 +1,5 @@
-import { CSSResultGroup, html } from "lit";
+import { CSSResultGroup } from "lit";
+import { html, unsafeStatic } from "lit/static-html.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 import { live } from "lit/directives/live.js";
 import { property, query, state } from "lit/decorators.js";
@@ -21,6 +22,7 @@ import {
 import { customElement } from "../../base/utilities/customElementDecorator";
 
 import { HTMLElement } from "@lit-labs/ssr-dom-shim";
+import { iconFormCheckedName, iconFormIndeterminateName } from "../../base/internal/icons";
 
 globalThis.HTMLElement ??= HTMLElement;
 
@@ -67,6 +69,8 @@ export class CheckboxInput extends ShoelaceElement implements ShoelaceFormContro
   private readonly hasSlotController = new HasSlotController(this, "help-text");
 
   @query('input[type="checkbox"]') input!: HTMLInputElement;
+
+  @property({ attribute: "id-value", reflect: true }) idValue = "";
 
   @property() title = ""; // make reactive to pass through
 
@@ -200,6 +204,11 @@ export class CheckboxInput extends ShoelaceElement implements ShoelaceFormContro
     const hasAlertElementSlot = this.hasSlotController.test("alert");
     const hasHelpText = this.helpText ? true : !!hasHelpTextSlot;
     const hasAlertElement = !!hasAlertElementSlot;
+    const icon = this.checked
+      ? html`<${unsafeStatic(iconFormCheckedName)} class="kobber-checkbox__control--shape"></${unsafeStatic(iconFormCheckedName)}>`
+      : this.indeterminate
+        ? html`<${unsafeStatic(iconFormIndeterminateName)} class="kobber-checkbox__control--shape"></${unsafeStatic(iconFormIndeterminateName)}>`
+        : "";
 
     return html`
       <div class="${checkboxWrapperClassName}">
@@ -209,7 +218,7 @@ export class CheckboxInput extends ShoelaceElement implements ShoelaceFormContro
             type="checkbox"
             title=${this.title /* An empty title prevents browser validation tooltips from appearing on hover */}
             name=${this.name}
-            value=${ifDefined(this.value)}
+            value=${ifDefined(this.idValue)}
             .checked=${live(this.checked)}
             .disabled=${this.disabled}
             .required=${this.required}
@@ -221,18 +230,7 @@ export class CheckboxInput extends ShoelaceElement implements ShoelaceFormContro
             @focus=${this.handleFocus}
           />
 
-          <span
-            part="control${this.checked ? " control--checked" : ""}${this.indeterminate
-              ? " control--indeterminate"
-              : ""}"
-            class=${checkboxControlClassName}
-          >
-            ${this.checked
-              ? html` <icon-form_checked part="checked-icon" /> `
-              : this.indeterminate
-                ? html` <icon-form_indeterminate part="checked-icon" /> `
-                : ""}
-          </span>
+          <span class=${checkboxControlClassName}> ${icon} </span>
 
           <div part="label" class=${checkboxLabelClassName}>
             <slot></slot>

--- a/packages/kobber-components/src/checkbox/checkbox-input/CheckboxInput.ts
+++ b/packages/kobber-components/src/checkbox/checkbox-input/CheckboxInput.ts
@@ -2,7 +2,7 @@ import { CSSResultGroup } from "lit";
 import { html, unsafeStatic } from "lit/static-html.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 import { live } from "lit/directives/live.js";
-import { property, query, state } from "lit/decorators.js";
+import { property, query } from "lit/decorators.js";
 import { checkboxStyles } from "./checkboxInput.styles";
 import { defaultValue } from "../../base/internal/default-value";
 import { watch } from "../../base/internal/watch";
@@ -110,18 +110,16 @@ export class CheckboxInput extends ShoelaceElement implements ShoelaceFormContro
   /** The checkbox's help text. If you need to display HTML, use the `help-text` slot instead. */
   @property({ attribute: "help-text" }) helpText = "";
 
-  /** Gets the validity state object */
-  get validity() {
-    return this.input.validity;
-  }
-
-  /** Gets the validation message */
-  get validationMessage() {
-    return this.input.validationMessage;
-  }
-
   firstUpdated() {
     this.formControlController.updateValidity();
+  }
+
+  private handleFocus() {
+    this.emit("focus");
+  }
+
+  private handleBlur() {
+    this.emit("blur");
   }
 
   private handleClick() {
@@ -130,34 +128,8 @@ export class CheckboxInput extends ShoelaceElement implements ShoelaceFormContro
     this.emit("change");
   }
 
-  private handleBlur() {
-    this.emit("blur");
-  }
-
   private handleInput() {
     this.emit("input");
-  }
-
-  private handleInvalid(event: Event) {
-    this.formControlController.setValidity(false);
-    this.formControlController.emitInvalidEvent(event);
-  }
-
-  private handleFocus() {
-    this.emit("focus");
-  }
-
-  @watch("disabled", { waitUntilFirstUpdate: true })
-  handleDisabledChange() {
-    // Disabled form controls are always valid
-    this.formControlController.setValidity(this.disabled);
-  }
-
-  @watch(["checked", "indeterminate"], { waitUntilFirstUpdate: true })
-  handleStateChange() {
-    this.input.checked = this.checked; // force a sync update
-    this.input.indeterminate = this.indeterminate; // force a sync update
-    this.formControlController.updateValidity();
   }
 
   /** Simulates a click on the checkbox. */
@@ -173,6 +145,21 @@ export class CheckboxInput extends ShoelaceElement implements ShoelaceFormContro
   /** Removes focus from the checkbox. */
   blur() {
     this.input.blur();
+  }
+
+  /** Gets the validity state object */
+  get validity() {
+    return this.input.validity;
+  }
+
+  /** Gets the validation message */
+  get validationMessage() {
+    return this.input.validationMessage;
+  }
+
+  private handleInvalid(event: Event) {
+    this.formControlController.setValidity(false);
+    this.formControlController.emitInvalidEvent(event);
   }
 
   /** Checks for validity but does not show a validation message. Returns `true` when valid and `false` when invalid. */
@@ -197,6 +184,19 @@ export class CheckboxInput extends ShoelaceElement implements ShoelaceFormContro
   setCustomValidity(message: string) {
     this.input.setCustomValidity(message);
     this.formControlController.updateValidity();
+  }
+
+  @watch(["checked", "indeterminate"], { waitUntilFirstUpdate: true })
+  handleStateChange() {
+    this.input.checked = this.checked; // force a sync update
+    this.input.indeterminate = this.indeterminate; // force a sync update
+    this.formControlController.updateValidity();
+  }
+
+  @watch("disabled", { waitUntilFirstUpdate: true })
+  handleDisabledChange() {
+    // Disabled form controls are always valid
+    this.formControlController.setValidity(this.disabled);
   }
 
   render() {

--- a/packages/kobber-components/src/checkbox/checkbox-input/CheckboxInput.ts
+++ b/packages/kobber-components/src/checkbox/checkbox-input/CheckboxInput.ts
@@ -53,6 +53,14 @@ globalThis.HTMLElement ??= HTMLElement;
 
 @customElement(checkboxInputName)
 export class CheckboxInput extends ShoelaceElement implements ShoelaceFormControl {
+  value: unknown;
+  defaultValue?: unknown;
+  pattern?: string | undefined;
+  min?: string | number | Date | undefined;
+  max?: string | number | Date | undefined;
+  step?: number | "any" | undefined;
+  minlength?: number | undefined;
+  maxlength?: number | undefined;
   static styles: CSSResultGroup = [componentStyles, checkboxStyles];
   // static dependencies = { "sl-icon": SlIcon };
 
@@ -76,9 +84,6 @@ export class CheckboxInput extends ShoelaceElement implements ShoelaceFormContro
 
   /** The name of the checkbox, submitted as a name/value pair with form data. */
   @property() name = "";
-
-  /** The current value of the checkbox, submitted as a name/value pair with form data. */
-  @property() value = "";
 
   @property() variant: CheckboxVariant = "success";
 

--- a/packages/kobber-components/src/checkbox/checkbox-input/checkboxInput.styles.ts
+++ b/packages/kobber-components/src/checkbox/checkbox-input/checkboxInput.styles.ts
@@ -8,6 +8,7 @@ import {
   NativeInputClassName,
   InputControlClassName,
   WrapperClassName,
+  CheckboxIconClassNames,
 } from "../Checkbox.core";
 
 const createCheckboxStyles = () => {
@@ -21,10 +22,10 @@ const createCheckboxStyles = () => {
     .${unsafeCSS("kobber-checkbox-wrapper" satisfies WrapperClassName)} {
       display: flex;
       flex-direction: column;
-      gap: var(--checkbox-inner-container-right-gap, 12px);
+      gap: 0 var(${unsafeCSS(checkbox["inner-container-right"].gap)});
     }
 
-    .${unsafeCSS("kobber-checkbox" satisfies CheckboxClassNames)} {
+    .${unsafeCSS("kobber-checkbox-input" satisfies CheckboxClassNames)} {
       display: flex;
       gap: var(${unsafeCSS(checkbox.container.gap)});
       justify-content: start;
@@ -42,10 +43,14 @@ const createCheckboxStyles = () => {
     }
     .${unsafeCSS("kobber-checkbox__label" satisfies InputLabelClassName)} {
       display: block;
+      color: var(${unsafeCSS(checkbox.text.color)});
     }
     .${unsafeCSS("kobber-checkbox__control" satisfies InputControlClassName)} {
       width: var(${unsafeCSS(checkbox.checkbox.width)});
       height: var(${unsafeCSS(checkbox.checkbox.height)});
+      display: flex;
+      align-items: center;
+      justify-content: center;
       border-radius: var(${unsafeCSS(checkbox.checkbox.outline.radius)});
       &:not([checked]) {
         border: var(${unsafeCSS(checkbox.checkbox.border.width)}) solid var(--control-border-color);
@@ -54,6 +59,10 @@ const createCheckboxStyles = () => {
       flex-shrink: 0;
       background-color: var(--control-background-color);
       transition: var(--transition-time) outline;
+    }
+    .${unsafeCSS("kobber-checkbox__control--shape" satisfies CheckboxIconClassNames)} {
+      display: flex;
+      align-items: center;
     }
     .${unsafeCSS("native-input" satisfies NativeInputClassName)} {
       pointer-events: none;
@@ -76,11 +85,12 @@ const variantStyles = () => {
 
 const statesPerVariant = (variant: CheckboxVariant) => {
   const outlineColor = component.checkbox.checkbox.outline.color[variant];
+  const borderColor = component.checkbox.checkbox.border.color[variant];
   const bgColor = component.checkbox.checkbox.background.color[variant];
   return css`
     & {
       --control-border-color: var(
-        ${unsafeCSS(component.checkbox.checkbox.border.color[variant].idle)}
+        ${unsafeCSS(borderColor.idle)}
       ); /* Must be first, to enable being overridden by non-idle styles. */
     }
 
@@ -88,7 +98,7 @@ const statesPerVariant = (variant: CheckboxVariant) => {
     :host(:hover) & {
       &:not(.disabled, [disabled]) {
         --control-outline-color: var(${unsafeCSS(outlineColor.hover)});
-        --control-border-color: var(${unsafeCSS(component.checkbox.checkbox.border.color[variant].hover)});
+        --control-border-color: var(${unsafeCSS(borderColor.hover)});
       }
     }
 
@@ -96,7 +106,19 @@ const statesPerVariant = (variant: CheckboxVariant) => {
     :host(:active) & {
       &:not(.disabled, [disabled]) {
         --control-outline-color: var(${unsafeCSS(outlineColor.active)});
-        --control-border-color: var(${unsafeCSS(component.checkbox.checkbox.border.color[variant].active)});
+        --control-border-color: var(${unsafeCSS(borderColor.active)});
+      }
+    }
+
+    &:focus-visible,
+    &.focus,
+    :host(:focus) &,
+    :host(:focus-visible) & {
+      &:not(.disabled, [disabled]) {
+        outline: none;
+        box-shadow: 0 0 0 var(${unsafeCSS(universal.focus.border.width)}) var(${unsafeCSS(universal.focus.color)});
+        border-radius: var(${unsafeCSS(universal.focus.border.radius.xsmall)});
+        --control-border-color: var(${unsafeCSS(borderColor.focus)});
       }
     }
 
@@ -119,17 +141,6 @@ const inputStates = () => {
       /* opacity: var(${unsafeCSS(universal.disabled.container.opacity)}); */
       opacity: 0.5;
       cursor: auto;
-    }
-
-    &:focus-visible,
-    &.focus,
-    :host(:focus) &,
-    :host(:focus-visible) & {
-      &:not(.disabled, [disabled]) {
-        outline: none;
-        box-shadow: 0 0 0 var(${unsafeCSS(universal.focus.border.width)}) var(${unsafeCSS(universal.focus.color)});
-        border-radius: var(${unsafeCSS(universal.focus.border.radius.xsmall)});
-      }
     }
   `;
 };

--- a/packages/kobber-components/src/index.react.ts
+++ b/packages/kobber-components/src/index.react.ts
@@ -13,6 +13,7 @@ import { CardLayout } from "./layouts/card-layout/CardLayout";
 import { CardLayoutColumnAspectRatio } from "./layouts/card-layout/CardLayoutColumnAspectRatio";
 import { Carousel } from "./carousel/Carousel";
 import { CarouselButton } from "./carousel/CarouselButton";
+import { CheckboxGroup } from "./checkbox/checkbox-group/CheckboxGroup";
 import { CheckboxInput } from "./checkbox/checkbox-input/CheckboxInput";
 import { Divider } from "./divider/Divider";
 import { Dropdown } from "./dropdown/Dropdown";
@@ -92,6 +93,12 @@ export const KobberCarousel = createComponent({
 export const KobberCarouselButton = createComponent({
   tagName: "kobber-carousel-button",
   elementClass: CarouselButton,
+  react: React,
+});
+
+export const KobberCheckboxGroup = createComponent({
+  tagName: "kobber-checkbox-group",
+  elementClass: CheckboxGroup,
   react: React,
 });
 

--- a/packages/kobber-components/src/index.web-components.ts
+++ b/packages/kobber-components/src/index.web-components.ts
@@ -8,6 +8,7 @@ export { CardLayout } from "./layouts/card-layout/CardLayout";
 export { CardLayoutColumnAspectRatio } from "./layouts/card-layout/CardLayoutColumnAspectRatio";
 export { Carousel } from "./carousel/Carousel";
 export { CarouselButton } from "./carousel/CarouselButton";
+export { CheckboxGroup } from "./checkbox/checkbox-group/CheckboxGroup";
 export { CheckboxInput } from "./checkbox/checkbox-input/CheckboxInput";
 export { Divider } from "./divider/Divider";
 export { Dropdown } from "./dropdown/Dropdown";

--- a/packages/kobber-components/src/radio/Radio.stories.ts
+++ b/packages/kobber-components/src/radio/Radio.stories.ts
@@ -204,7 +204,7 @@ export const GNOExample: Story = {
 
       <div class="wrapper-theme">
         <kobber-radio-group current-value="${args.currentValue}" direction="${args.direction}">
-        <p slot="label" class="${!args.showLabel ? "visually-hidden" : ""}">
+        <p slot="label">
           Formater (ref <a href="https://en.wikipedia.org/wiki/Paperback">Wikipedia</a>):
         </p>
         
@@ -248,8 +248,6 @@ export const GNOExample: Story = {
     currentValue: "ebook",
     direction: "horizontal",
     showHelpText: true,
-    showLabel: true,
-    link: true,
     variant: inputVariants[0],
   },
 };

--- a/packages/kobber-components/src/radio/radio-group/RadioGroup.ts
+++ b/packages/kobber-components/src/radio/radio-group/RadioGroup.ts
@@ -18,12 +18,12 @@ import { radioGroupStyles } from "./RadioGroup.styles";
 import { customElement } from "../../base/utilities/customElementDecorator";
 
 /**
- * @summary Radio groups are used to group multiple [radios](/components/radio) or [radio buttons](/components/radio-button) so they function as a single form control.
+ * @summary Radio groups are used to group multiple [radio inputs](/components/radio-input) so they function as a single form control.
  * @documentation https://shoelace.style/components/radio-group
  * @status stable
  * @since 2.0
  *
- * @slot - The default slot where `<kobber-radio-button>` elements are placed.
+ * @slot - The default slot where `<kobber-radio-input>` elements are placed.
  * @slot label - The radio group's label. Required for proper accessibility. Alternatively, you can use the `label`
  *  attribute.
  * @slot help-text - Text that describes how to use the radio group. Alternatively, you can use the `help-text` attribute.
@@ -96,6 +96,15 @@ export class RadioGroup extends ShoelaceElement implements Props {
   constructor() {
     super();
   }
+  defaultValue?: unknown;
+  pattern?: string | undefined;
+  min?: string | number | Date | undefined;
+  max?: string | number | Date | undefined;
+  step?: number | "any" | undefined;
+  minlength?: number | undefined;
+  maxlength?: number | undefined;
+  checked?: boolean | undefined;
+  indeterminate?: boolean | undefined;
 
   connectedCallback() {
     super.connectedCallback();
@@ -223,16 +232,14 @@ export class RadioGroup extends ShoelaceElement implements Props {
 
   @watch("value")
   handleValueChange() {
-    if (this.hasUpdated) {
-      this.updateCheckedRadio();
-    }
+    this.updateCheckedRadio();
   }
 
   @watch("url")
   handleUrlChange() {
     if (window.location.href !== this.url) {
       this.url = window.location.href;
-      this.syncRadioElements();
+      this.syncRadios();
     }
   }
 

--- a/packages/kobber-components/src/radio/radio-group/RadioGroup.ts
+++ b/packages/kobber-components/src/radio/radio-group/RadioGroup.ts
@@ -51,8 +51,6 @@ export class RadioGroup extends ShoelaceElement implements Props {
 
   @query("slot:not([name])") defaultSlot!: HTMLSlotElement;
 
-  @state() private url = window.location.href;
-
   @property({ attribute: "current-value" }) currentValue = "";
 
   /**
@@ -78,6 +76,9 @@ export class RadioGroup extends ShoelaceElement implements Props {
 
   /** Ensures a child radio is checked before allowing the containing form to submit. */
   @property({ type: Boolean, reflect: true }) required = false;
+
+  /** Applicable when used as a button that redirects to url. */
+  @state() private url = window.location.href;
 
   /** Gets the validity state object */
   get validity() {
@@ -109,12 +110,10 @@ export class RadioGroup extends ShoelaceElement implements Props {
   connectedCallback() {
     super.connectedCallback();
     this.value = this.currentValue;
-    /* eslint-disable @typescript-eslint/no-explicit-any */
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
-    navigation.addEventListener("navigate", (e: any) => {
+    navigation.addEventListener("navigate", () => {
       // Experimental functionality, does not work in Firefox. Might change in the future.
-      /* eslint-enable @typescript-eslint/no-explicit-any */
       this.handleUrlChange();
     });
   }
@@ -125,6 +124,76 @@ export class RadioGroup extends ShoelaceElement implements Props {
 
   private getAllRadios() {
     return [...this.querySelectorAll<RadioInput>(radioInputName)];
+  }
+
+  private async syncRadioElements() {
+    const radios = this.getAllRadios();
+
+    await Promise.all(
+      // Sync the checked state and size
+      radios.map(async radio => {
+        await radio.updateComplete;
+        if (radio.href !== "") {
+          radio.checked = this.url.includes(radio.href);
+        } else {
+          radio.checked = radio.value === this.value;
+        }
+      }),
+    );
+
+    if (radios.length > 0 && !radios.some(radio => radio.checked)) {
+      radios[0]!.setAttribute("tabindex", "0");
+    }
+  }
+
+  private syncRadios() {
+    if (customElements.get(radioInputName)) {
+      this.syncRadioElements();
+      return;
+    }
+
+    if (customElements.get(radioInputName)) {
+      this.syncRadioElements();
+    } else {
+      customElements.whenDefined(radioInputName).then(() => this.syncRadios());
+    }
+  }
+
+  /** Checks for validity but does not show a validation message. Returns `true` when valid and `false` when invalid. */
+  checkValidity() {
+    const isRequiredAndEmpty = this.required && !this.value;
+    const hasCustomValidityMessage = this.customValidityMessage !== "";
+
+    if (isRequiredAndEmpty || hasCustomValidityMessage) {
+      this.formControlController.emitInvalidEvent();
+      return false;
+    }
+
+    return true;
+  }
+
+  /** Gets the associated form, if one exists. */
+  getForm(): HTMLFormElement | null {
+    return this.formControlController.getForm();
+  }
+
+  /** Checks for validity and shows the browser's validation message if the control is invalid. */
+  reportValidity(): boolean {
+    const isValid = this.validity.valid;
+
+    this.formControlController.setValidity(isValid);
+
+    return isValid;
+  }
+
+  /** Sets a custom validation message. Pass an empty string to restore validity. */
+  setCustomValidity(message = "") {
+    this.customValidityMessage = message;
+    this.formControlController.updateValidity();
+  }
+
+  private handleLabelClick() {
+    this.focus();
   }
 
   private handleRadioClick(event: MouseEvent) {
@@ -182,98 +251,10 @@ export class RadioGroup extends ShoelaceElement implements Props {
     event.preventDefault();
   }
 
-  private handleLabelClick() {
-    this.focus();
-  }
-
-  private async syncRadioElements() {
-    const radios = this.getAllRadios();
-
-    await Promise.all(
-      // Sync the checked state and size
-      radios.map(async radio => {
-        await radio.updateComplete;
-        if (radio.href !== "") {
-          radio.checked = this.url.includes(radio.href);
-        } else {
-          radio.checked = radio.value === this.value;
-        }
-      }),
-    );
-
-    if (radios.length > 0 && !radios.some(radio => radio.checked)) {
-      radios[0]!.setAttribute("tabindex", "0");
-    }
-  }
-
-  private syncRadios() {
-    if (customElements.get(radioInputName)) {
-      this.syncRadioElements();
-      return;
-    }
-
-    if (customElements.get(radioInputName)) {
-      this.syncRadioElements();
-    } else {
-      customElements.whenDefined(radioInputName).then(() => this.syncRadios());
-    }
-  }
-
   private updateCheckedRadio() {
     const radios = this.getAllRadios();
     radios.forEach(radio => (radio.checked = radio.value === this.value));
     this.formControlController.setValidity(this.validity.valid);
-  }
-
-  @watch("size", { waitUntilFirstUpdate: true })
-  handleSizeChange() {
-    this.syncRadios();
-  }
-
-  @watch("value")
-  handleValueChange() {
-    this.updateCheckedRadio();
-  }
-
-  @watch("url")
-  handleUrlChange() {
-    if (window.location.href !== this.url) {
-      this.url = window.location.href;
-      this.syncRadios();
-    }
-  }
-
-  /** Checks for validity but does not show a validation message. Returns `true` when valid and `false` when invalid. */
-  checkValidity() {
-    const isRequiredAndEmpty = this.required && !this.value;
-    const hasCustomValidityMessage = this.customValidityMessage !== "";
-
-    if (isRequiredAndEmpty || hasCustomValidityMessage) {
-      this.formControlController.emitInvalidEvent();
-      return false;
-    }
-
-    return true;
-  }
-
-  /** Gets the associated form, if one exists. */
-  getForm(): HTMLFormElement | null {
-    return this.formControlController.getForm();
-  }
-
-  /** Checks for validity and shows the browser's validation message if the control is invalid. */
-  reportValidity(): boolean {
-    const isValid = this.validity.valid;
-
-    this.formControlController.setValidity(isValid);
-
-    return isValid;
-  }
-
-  /** Sets a custom validation message. Pass an empty string to restore validity. */
-  setCustomValidity(message = "") {
-    this.customValidityMessage = message;
-    this.formControlController.updateValidity();
   }
 
   /** Sets focus on the radio-group. */
@@ -291,6 +272,24 @@ export class RadioGroup extends ShoelaceElement implements Props {
     const radioToFocus = checked || firstEnabledRadio;
     if (radioToFocus) {
       radioToFocus.focus(options);
+    }
+  }
+
+  @watch("size", { waitUntilFirstUpdate: true })
+  handleSizeChange() {
+    this.syncRadios();
+  }
+
+  @watch("value")
+  handleValueChange() {
+    this.updateCheckedRadio();
+  }
+
+  @watch("url")
+  handleUrlChange() {
+    if (window.location.href !== this.url) {
+      this.url = window.location.href;
+      this.syncRadios();
     }
   }
 

--- a/packages/kobber-components/src/radio/radio-input/RadioInput.ts
+++ b/packages/kobber-components/src/radio/radio-input/RadioInput.ts
@@ -1,13 +1,21 @@
-import { html } from "lit";
+import { html, unsafeStatic } from "lit/static-html.js";
 import { property, state } from "lit/decorators.js";
 import { watch } from "../../base/internal/watch";
 import ShoelaceElement from "../../base/internal/shoelace-element";
 import componentStyles from "../../base/styles/component.styles";
 import { radioInputStyles } from "./RadioInput.styles";
 import type { CSSResultGroup } from "lit";
-import { inputClassNames, radioInputName, InputVariant, radioInputLabelClassName, InputProps } from "../Radio.core";
+import {
+  inputClassNames,
+  radioInputName,
+  InputVariant,
+  radioInputLabelClassName,
+  InputProps,
+  radioInputControlName,
+} from "../Radio.core";
 import "../radio-input-control/RadioInputControl";
 import "../../button/Button";
+import { buttonName } from "../../button/Button.core";
 import { customElement } from "../../base/utilities/customElementDecorator";
 
 /**
@@ -94,9 +102,11 @@ export class RadioInput extends ShoelaceElement implements InputProps {
 
   render() {
     const isLink = this.isLink();
+    const buttonElement = unsafeStatic(buttonName);
+    const radioInputControlElement = unsafeStatic(radioInputControlName);
 
     if (isLink) {
-      return html`<kobber-button
+      return html`<${buttonElement}
         class=${[
           ...inputClassNames({
             variant: this.variant,
@@ -110,13 +120,13 @@ export class RadioInput extends ShoelaceElement implements InputProps {
         usedInOtherInteractive
         iconFirst
       >
-        <kobber-radio-input-control
+        <${radioInputControlElement}
           ?checked="${this.checked}"
           variant="${this.variant}"
           slot="icon"
-        ></kobber-radio-input-control>
+        ></${radioInputControlElement}>
         <slot part="label"></slot>
-      </kobber-button>`;
+      </${buttonElement}>`;
     }
     return html`
       <div
@@ -128,7 +138,7 @@ export class RadioInput extends ShoelaceElement implements InputProps {
           this.className,
         ].join(" ")}
       >
-        <kobber-radio-input-control ?checked="${this.checked}" variant="${this.variant}"></kobber-radio-input-control>
+        <${radioInputControlElement} ?checked="${this.checked}" variant="${this.variant}"></${radioInputControlElement}>
         <slot part="label" class="${radioInputLabelClassName}"></slot>
       </div>
     `;

--- a/packages/kobber-components/src/radio/radio-input/RadioInput.ts
+++ b/packages/kobber-components/src/radio/radio-input/RadioInput.ts
@@ -64,6 +64,13 @@ export class RadioInput extends ShoelaceElement implements InputProps {
     this.setInitialAttributes();
   }
 
+  private handleFocus = () => {
+    if (this.isLink()) {
+      window.location.href = this.href;
+    }
+    this.hasFocus = true;
+  };
+
   private handleBlur = () => {
     this.hasFocus = false;
   };
@@ -72,13 +79,6 @@ export class RadioInput extends ShoelaceElement implements InputProps {
     if (!this.disabled) {
       this.checked = true;
     }
-  };
-
-  private handleFocus = () => {
-    if (this.isLink()) {
-      window.location.href = this.href;
-    }
-    this.hasFocus = true;
   };
 
   private setInitialAttributes() {


### PR DESCRIPTION
PR-en gjør at checkboxer kan ordnes i grupper med en box som gjelder hele gruppa:

![image](https://github.com/user-attachments/assets/54d4a37d-e033-437b-899b-43e647a5379d)

Fremdeles gjenstår pirk (som å hindre at radio og checkbox får på seg fokusmarkering ved klikk), og litt større ting (som håndtering av validering for disse komponentene).