### PR TITLE
Clean up naming, type-checking, and property types across components

### DIFF
--- a/apps/docs/app/(web)/(routes)/_hero-banner.tsx
+++ b/apps/docs/app/(web)/(routes)/_hero-banner.tsx
@@ -19,7 +19,7 @@ export function HeroBanner() {
       <KobberTextWrapper>
         <KobberHeading>
           Velkommen til Kobber
-          <KobberHeading level="div" variant="secondary">
+          <KobberHeading level="div" color-level="secondary">
             <em>Gyldendals designsystem</em>
           </KobberHeading>
         </KobberHeading>

--- a/apps/docs/components/global/restricted.tsx
+++ b/apps/docs/components/global/restricted.tsx
@@ -10,7 +10,7 @@ export function Restricted() {
         <KobberHeading>
           Kobber
           <br />
-          <KobberHeading level="span" variant="secondary">
+          <KobberHeading level="span" color-level="secondary">
             <em>Gyldendals Designsystem</em>
           </KobberHeading>
         </KobberHeading>

--- a/apps/docs/components/page-builder/rich-text.tsx
+++ b/apps/docs/components/page-builder/rich-text.tsx
@@ -22,7 +22,7 @@ const components: Partial<PortableTextReactComponents> = {
     h2: ({ children, value }) => {
       const slug = parseChildrenToSlug(value.children)
       return (
-        <KobberHeading id={slug} level="h2" element="title" size="medium" variant="primary">
+        <KobberHeading id={slug} level="h2" element="title" size="medium" color-level="primary">
           {children}
         </KobberHeading>
       )
@@ -30,7 +30,7 @@ const components: Partial<PortableTextReactComponents> = {
     h2Italic: ({ children, value }) => {
       const slug = parseChildrenToSlug(value.children)
       return (
-        <KobberHeading id={slug} level="h2" element="display" size="small" variant="secondary">
+        <KobberHeading id={slug} level="h2" element="display" size="small" color-level="secondary">
           {children}
         </KobberHeading>
       )

--- a/apps/docs/components/page-builder/sections/color-list/color-list-block-item.tsx
+++ b/apps/docs/components/page-builder/sections/color-list/color-list-block-item.tsx
@@ -33,7 +33,7 @@ export const ColorListItem = (props: ItemProps) => {
         }}
       ></div>
       <div className={styles["color-list-item-content"]}>
-        <KobberHeading level="h3" element="title" size="small" variant="primary">
+        <KobberHeading level="h3" element="title" size="small" color-level="primary">
           {title}
         </KobberHeading>
 

--- a/packages/kobber-components/src/badge-icon/BadgeIcon.core.ts
+++ b/packages/kobber-components/src/badge-icon/BadgeIcon.core.ts
@@ -1,4 +1,5 @@
 import { component } from "@gyldendal/kobber-base/themes/tokens.css-variables.js";
+import { objectKeys } from "../base/utilities/objectKeys";
 
 const badgeIconTokens = component["badge-icon"];
 
@@ -6,17 +7,17 @@ export const badgeIconName = "kobber-badge-icon";
 export const badgeIconIconName = "icon";
 
 export type BadgeIconProps = {
-  variant?: BadgeIconVariant;
-  theme?: BadgeIconTheme;
+  colorVariant?: BadgeIconColorVariant;
+  colorTheme?: BadgeIconColorTheme;
   size?: BadgeIconSize;
 };
 
 export type BadgeIconClassName = typeof badgeIconName;
 export type BadgeIconIconClassName = typeof badgeIconIconName;
-export type BadgeIconTheme = keyof typeof badgeIconTokens.text.color;
-export type BadgeIconVariant = keyof (typeof badgeIconTokens.text.color)[BadgeIconTheme];
-export type BadgeIconSize = keyof typeof badgeIconTokens.gap;
+export type BadgeIconColorTheme = (typeof badgeIconColorThemes)[number];
+export type BadgeIconColorVariant = (typeof badgeIconColorVariants)[number];
+export type BadgeIconSize = (typeof badgeIconSizes)[number];
 
-export const badgeIconThemes = Object.keys(badgeIconTokens.text.color) as BadgeIconTheme[];
-export const badgeIconVariants = Object.keys(badgeIconTokens.text.color.aubergine) as BadgeIconVariant[];
-export const badgeIconSizes = Object.keys(badgeIconTokens.gap) as BadgeIconSize[];
+export const badgeIconColorThemes = objectKeys(badgeIconTokens.text.color);
+export const badgeIconColorVariants = objectKeys(badgeIconTokens.text.color.aubergine);
+export const badgeIconSizes = objectKeys(badgeIconTokens.gap);

--- a/packages/kobber-components/src/badge-icon/BadgeIcon.stories.ts
+++ b/packages/kobber-components/src/badge-icon/BadgeIcon.stories.ts
@@ -1,7 +1,13 @@
 import type { Meta, StoryObj } from "@storybook/web-components-vite";
 import { html } from "lit";
 import "./BadgeIcon";
-import { badgeIconName, BadgeIconProps, badgeIconSizes, badgeIconThemes, badgeIconVariants } from "./BadgeIcon.core";
+import {
+  badgeIconName,
+  BadgeIconProps,
+  badgeIconSizes,
+  badgeIconColorThemes,
+  badgeIconColorVariants,
+} from "./BadgeIcon.core";
 import "@gyldendal/kobber-icons/web-components";
 import "../theme-context-provider/ThemeContext";
 import { init as initComponents } from "../base/init";
@@ -33,20 +39,20 @@ export const BadgeIcons: StoryObj<Args> = {
       options: badgeIconSizes,
       control: { type: "select" },
     },
-    theme: {
-      options: badgeIconThemes,
+    colorTheme: {
+      options: badgeIconColorThemes,
       control: { type: "select" },
     },
-    variant: {
-      options: badgeIconVariants,
+    colorVariant: {
+      options: badgeIconColorVariants,
       control: { type: "select" },
     },
   },
   args: {
     text: "Badge Icon",
     size: "medium",
-    theme: "aubergine",
-    variant: "main",
+    colorTheme: "aubergine",
+    colorVariant: "main",
   },
   render: args => {
     return html`${renderBadgeIcon(args)}`;
@@ -54,9 +60,9 @@ export const BadgeIcons: StoryObj<Args> = {
 };
 
 const renderBadgeIcon = (args: Args) => {
-  const { size, text, theme, variant } = args;
+  const { size, text, colorTheme, colorVariant } = args;
 
-  return html` <kobber-badge-icon size=${size} theme=${theme} variant=${variant}>
+  return html` <kobber-badge-icon size=${size} color-theme=${colorTheme} color-variant=${colorVariant}>
     <kobber-arrow_right slot="icon"></kobber-arrow_right>
     <span slot="text">${text}</span>
   </kobber-badge-icon>`;

--- a/packages/kobber-components/src/badge-icon/BadgeIcon.styles.ts
+++ b/packages/kobber-components/src/badge-icon/BadgeIcon.styles.ts
@@ -1,18 +1,16 @@
-import { component, universal } from "@gyldendal/kobber-base/themes/tokens.css-variables.js";
+import { component } from "@gyldendal/kobber-base/themes/tokens.css-variables.js";
 import { css, unsafeCSS } from "lit";
 import {
   BadgeIconClassName,
   BadgeIconIconClassName,
   badgeIconName,
-  BadgeIconSize,
   badgeIconSizes,
-  badgeIconThemes,
-  badgeIconVariants,
+  badgeIconColorThemes,
+  badgeIconColorVariants,
 } from "./BadgeIcon.core";
 import { getTypographyStyles } from "../base/getTypographyStyles";
 
 const containerStyles = component["badge-icon"];
-const textStyles = universal.text.ui;
 
 const createBadgeIconStyles = () => {
   return css`
@@ -48,13 +46,13 @@ const createBadgeIconStyles = () => {
 const getThemeStyles = () => {
   return css`
     ${unsafeCSS(
-      badgeIconThemes
-        .flatMap(theme => {
+      badgeIconColorThemes
+        .flatMap(colorTheme => {
           return badgeIconSizes.flatMap(size =>
-            badgeIconVariants.flatMap(
-              variant =>
-                `&[data-variant="${variant}"][data-theme="${theme}"][data-size="${size}"] { 
-                  --color: var(${unsafeCSS(component["badge-icon"].text.color[theme][variant])});
+            badgeIconColorVariants.flatMap(
+              colorVariant =>
+                `&[data-color-variant="${colorVariant}"][data-color-theme="${colorTheme}"][data-size="${size}"] { 
+                  --color: var(${unsafeCSS(component["badge-icon"].text.color[colorTheme][colorVariant])});
                 }`,
             ),
           );

--- a/packages/kobber-components/src/badge-icon/BadgeIcon.ts
+++ b/packages/kobber-components/src/badge-icon/BadgeIcon.ts
@@ -9,13 +9,13 @@ import { customElement } from "../base/utilities/customElementDecorator";
 export class BadgeIcon extends LitElement implements BadgeIconProps {
   static styles: CSSResultGroup = [componentStyles, badgeIconStyles];
 
-  @property({ type: String })
-  variant?: BadgeIconProps["variant"] = "main";
+  @property({ attribute: "color-theme" })
+  colorTheme: BadgeIconProps["colorTheme"] = "aubergine";
 
-  @property({ type: String })
-  theme?: BadgeIconProps["theme"] = "nature";
+  @property({ attribute: "color-variant" })
+  colorVariant: BadgeIconProps["colorVariant"] = "main";
 
-  @property({ type: String })
+  @property()
   size?: BadgeIconProps["size"] = "medium";
 
   connectedCallback() {
@@ -25,9 +25,9 @@ export class BadgeIcon extends LitElement implements BadgeIconProps {
   render() {
     return html` <div
       class="${badgeIconName}"
-      data-variant="${this.variant}"
+      data-color-variant="${this.colorVariant}"
+      data-color-theme="${this.colorTheme}"
       data-size="${this.size}"
-      data-theme="${this.theme}"
     >
       <slot name="icon"></slot>
       <slot name="text"></slot>

--- a/packages/kobber-components/src/badge/Badge.core.ts
+++ b/packages/kobber-components/src/badge/Badge.core.ts
@@ -1,4 +1,5 @@
 import { component } from "@gyldendal/kobber-base/themes/tokens.css-variables.js";
+import { objectKeys } from "../base/utilities/objectKeys";
 
 const badgeTokens = component.badge;
 
@@ -15,17 +16,17 @@ export const badgeClassNames = ({ showStatusCircle = false }: BadgeProps): Badge
 };
 
 export type BadgeProps = {
-  theme?: BadgeTheme;
-  variant?: BadgeVariant;
+  colorTheme?: BadgeColorTheme;
+  colorVariant?: BadgeColorVariant;
   size?: BadgeSize;
   showStatusCircle?: boolean;
 };
 
 export type BadgeClassNames = typeof badgeName | "status-circle";
-export type BadgeTheme = keyof typeof badgeTokens.background.color;
-export type BadgeVariant = keyof typeof badgeTokens.background.color.aubergine;
-export type BadgeSize = keyof typeof badgeTokens.gap;
+export type BadgeColorTheme = (typeof badgeColorThemes)[number];
+export type BadgeColorVariant = (typeof badgeColorVariants)[number];
+export type BadgeSize = (typeof badgeSizes)[number];
 
-export const badgeThemes = Object.keys(badgeTokens.background.color) as BadgeTheme[];
-export const badgeVariants = Object.keys(badgeTokens.text.color.aubergine) as BadgeVariant[];
-export const badgeSizes = Object.keys(badgeTokens.gap) as BadgeSize[];
+export const badgeColorThemes = objectKeys(badgeTokens.background.color);
+export const badgeColorVariants = objectKeys(badgeTokens.text.color.aubergine);
+export const badgeSizes = objectKeys(badgeTokens.gap);

--- a/packages/kobber-components/src/badge/Badge.stories.ts
+++ b/packages/kobber-components/src/badge/Badge.stories.ts
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/web-components-vite";
 import { html } from "lit";
 import "./Badge";
-import { badgeName, BadgeProps, badgeSizes, badgeThemes, badgeVariants } from "./Badge.core";
+import { badgeName, BadgeProps, badgeSizes, badgeColorThemes, badgeColorVariants } from "./Badge.core";
 import "../theme-context-provider/ThemeContext";
 import { init as initComponents } from "../base/init";
 
@@ -29,12 +29,12 @@ export const Badge: StoryObj<Args> = {
       options: badgeSizes,
       control: { type: "select" },
     },
-    theme: {
-      options: badgeThemes,
+    colorTheme: {
+      options: badgeColorThemes,
       control: { type: "select" },
     },
-    variant: {
-      options: badgeVariants,
+    colorVariant: {
+      options: badgeColorVariants,
       control: { type: "select" },
     },
     showStatusCircle: {
@@ -44,8 +44,8 @@ export const Badge: StoryObj<Args> = {
   args: {
     text: "Badge",
     size: "medium",
-    theme: "aubergine",
-    variant: "main",
+    colorTheme: "aubergine",
+    colorVariant: "main",
     showStatusCircle: true,
   },
   render: args => {
@@ -54,9 +54,14 @@ export const Badge: StoryObj<Args> = {
 };
 
 const renderBadge = (args: Args) => {
-  const { size, text, theme, variant, showStatusCircle } = args;
+  const { size, text, colorTheme, colorVariant, showStatusCircle } = args;
 
-  return html` <kobber-badge size=${size} theme=${theme} variant=${variant} ?showStatusCircle=${showStatusCircle}>
+  return html` <kobber-badge
+    size=${size}
+    color-theme=${colorTheme}
+    color-variant=${colorVariant}
+    ?showStatusCircle=${showStatusCircle}
+  >
     ${text}
   </kobber-badge>`;
 };

--- a/packages/kobber-components/src/badge/Badge.styles.ts
+++ b/packages/kobber-components/src/badge/Badge.styles.ts
@@ -1,11 +1,16 @@
-import { component, universal } from "@gyldendal/kobber-base/themes/tokens.css-variables.js";
-import { universal as UniversalType } from "@gyldendal/kobber-base/dist/themes/default/tokens.d.ts";
+import { component } from "@gyldendal/kobber-base/themes/tokens.css-variables.js";
 import { css, unsafeCSS } from "lit";
-import { BadgeClassNames, badgeSizes, badgeThemes, badgeVariants, BadgeVariant, BadgeSize } from "./Badge.core";
+import {
+  BadgeClassNames,
+  badgeSizes,
+  badgeColorThemes,
+  badgeColorVariants,
+  BadgeColorVariant,
+  BadgeSize,
+} from "./Badge.core";
 import { getTypographyStyles } from "../base/getTypographyStyles";
 
 const badge = component.badge;
-const textStyles = universal.text.ui;
 
 const createBadgeStyles = () => {
   return css`
@@ -44,17 +49,17 @@ const createBadgeStyles = () => {
 const getThemeStyles = () => {
   return css`
     ${unsafeCSS(
-      badgeThemes
-        .flatMap(theme => {
-          if (theme === "concrete") {
-            return `&[data-theme="${theme}"] { ${getConcreteThemeMainVariantStyles()} }`;
+      badgeColorThemes
+        .flatMap(colorTheme => {
+          if (colorTheme === "concrete") {
+            return `&[data-color-theme="${colorTheme}"] { ${getConcreteThemeMainVariantStyles()} }`;
           }
           return badgeSizes.flatMap(size =>
-            badgeVariants.flatMap(
-              variant =>
-                `&[data-variant="${variant}"][data-theme="${theme}"][data-size="${size}"] { 
-                  ${getNotConcreteThemeVariantStyles(theme, variant)}
-                  ${getNotConcreteThemeSupplementalVariantStyles(theme, variant, size)}
+            badgeColorVariants.flatMap(
+              colorVariant =>
+                `&[data-color-variant="${colorVariant}"][data-color-theme="${colorTheme}"][data-size="${size}"] { 
+                  ${getNotConcreteThemeVariantStyles(colorTheme, colorVariant)}
+                  ${getNotConcreteThemeSupplementalVariantStyles(colorTheme, colorVariant, size)}
                 }`,
             ),
           );
@@ -73,25 +78,25 @@ const getConcreteThemeMainVariantStyles = () => {
   `;
 };
 
-const getNotConcreteThemeVariantStyles = (theme: "aubergine" | "rettsdata", variant: BadgeVariant) => {
+const getNotConcreteThemeVariantStyles = (colorTheme: "aubergine" | "rettsdata", colorVariant: BadgeColorVariant) => {
   return css`
     ${unsafeCSS(`
-      --background-color: var(${unsafeCSS(badge.background.color[theme][variant])});
-      --color: var(${unsafeCSS(badge.text.color[theme][variant])});
+      --background-color: var(${unsafeCSS(badge.background.color[colorTheme][colorVariant])});
+      --color: var(${unsafeCSS(badge.text.color[colorTheme][colorVariant])});
       `)}
   `;
 };
 
 const getNotConcreteThemeSupplementalVariantStyles = (
-  theme: "aubergine" | "rettsdata",
-  variant: BadgeVariant,
+  colorTheme: "aubergine" | "rettsdata",
+  colorVariant: BadgeColorVariant,
   size: BadgeSize,
 ) => {
-  if (variant === "supplemental") {
+  if (colorVariant === "supplemental") {
     const circleStyles = component.badge["status-circle"];
     return css`
       ${unsafeCSS(`
-        --status-circle-color: var(${unsafeCSS(circleStyles.color[theme].supplemental)});
+        --status-circle-color: var(${unsafeCSS(circleStyles.color[colorTheme].supplemental)});
         --status-circle-width: var(${unsafeCSS(circleStyles.width[size])});
         --status-circle-height: var(${unsafeCSS(circleStyles.height[size])});
       `)}

--- a/packages/kobber-components/src/badge/Badge.ts
+++ b/packages/kobber-components/src/badge/Badge.ts
@@ -13,16 +13,16 @@ import { customElement } from "../base/utilities/customElementDecorator";
 export class Badge extends LitElement implements BadgeProps {
   static styles: CSSResultGroup = [componentStyles, badgeStyles];
 
-  @property({ type: String })
-  variant?: BadgeProps["variant"] = "main";
+  @property({ attribute: "color-theme" })
+  colorTheme?: BadgeProps["colorTheme"] = "aubergine";
 
-  @property({ type: String })
-  theme?: BadgeProps["theme"] = "aubergine";
+  @property({ attribute: "color-variant" })
+  colorVariant?: BadgeProps["colorVariant"] = "main";
 
-  @property({ type: String })
+  @property()
   size?: BadgeProps["size"] = "medium";
 
-  @property({ type: Boolean })
+  @property()
   showStatusCircle?: BadgeProps["showStatusCircle"];
 
   connectedCallback() {
@@ -37,9 +37,9 @@ export class Badge extends LitElement implements BadgeProps {
         }),
         this.className,
       ].join(" ")}"
-      data-variant="${this.variant}"
+      data-color-variant="${this.colorVariant}"
+      data-color-theme="${this.colorTheme}"
       data-size="${this.size}"
-      data-theme="${this.theme}"
     >
       ${this.showStatusCircle ? html`<div class="status-circle"></div>` : ""}
       <slot></slot>

--- a/packages/kobber-components/src/checkbox/Checkbox.core.ts
+++ b/packages/kobber-components/src/checkbox/Checkbox.core.ts
@@ -1,4 +1,5 @@
 import { component } from "@gyldendal/kobber-base/themes/default/tokens.js";
+import { objectKeys } from "../base/utilities/objectKeys";
 
 export const checkboxGroupName = "kobber-checkbox-group";
 export const checkboxWrapperClassName = "wrapper";
@@ -31,18 +32,18 @@ export type InputProps = {
   state?: CheckboxState;
   title?: string;
   value?: string;
-  variant?: CheckboxVariant;
+  colorTheme?: CheckboxColorTheme;
 };
 
 export type GroupClassNames = typeof checkboxGroupName;
-export type WrapperClassName = typeof checkboxWrapperClassName;
-export type CheckboxClassName = typeof checkboxInputName;
-export type NativeInputClassName = typeof nativeCheckboxInputClassName;
-export type InputLabelClassName = typeof checkboxLabelClassName;
-export type InputControlClassName = typeof checkboxControlClassName;
-export type IconClassName = typeof checkboxIconClassName;
+export type WrapperClassNames = typeof checkboxWrapperClassName;
+export type CheckboxClassNames = typeof checkboxInputName;
+export type NativeInputClassNames = typeof nativeCheckboxInputClassName;
+export type InputLabelClassNames = typeof checkboxLabelClassName;
+export type InputControlClassNames = typeof checkboxControlClassName;
+export type IconClassNames = typeof checkboxIconClassName;
 
 export type CheckboxState = keyof typeof checkboxTokens.border.color.success | "disabled";
-export type CheckboxVariant = keyof typeof checkboxTokens.border.color;
+export type CheckboxColorTheme = (typeof checkboxColorThemes)[number];
 
-export const checkboxVariants = Object.keys(component._checkbox.indicator.border.color) as CheckboxVariant[];
+export const checkboxColorThemes = objectKeys(component._checkbox.indicator.border.color);

--- a/packages/kobber-components/src/checkbox/Checkbox.mdx
+++ b/packages/kobber-components/src/checkbox/Checkbox.mdx
@@ -29,6 +29,6 @@ Keyboard navigation: Use tab to reach the Checkbox group, and <a href="https://w
 </details>
 
 <figure>
-  <figcaption>Kobber Checkbox Input Variants (only static examples, not intended for interaction)</figcaption>
-  <Story of={CheckboxStories.Variants} />
+  <figcaption>Kobber Checkbox Input Themes (only static examples, not intended for interaction)</figcaption>
+  <Story of={CheckboxStories.Themes} />
 </figure>

--- a/packages/kobber-components/src/checkbox/Checkbox.stories.ts
+++ b/packages/kobber-components/src/checkbox/Checkbox.stories.ts
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from "@storybook/web-components-vite";
 import "./checkbox-input/CheckboxInput";
 import "./checkbox-group/CheckboxGroup";
 import "../theme-context-provider/ThemeContext";
-import { InputProps, CheckboxState, checkboxVariants } from "./Checkbox.core";
+import { InputProps, CheckboxState, checkboxColorThemes } from "./Checkbox.core";
 import { init as initComponents } from "../base/init";
 
 initComponents();
@@ -32,7 +32,7 @@ const meta: Meta = {
 export default meta;
 type Story = StoryObj;
 
-export const Variants: Story = {
+export const Themes: Story = {
   render: args => {
     return `
       <style>
@@ -70,10 +70,10 @@ export const Variants: Story = {
       </style>
 
       <ol>
-        ${checkboxVariants
-          .map(variant =>
-            renderVariant({
-              variant,
+        ${checkboxColorThemes
+          .map(colorTheme =>
+            renderColorTheme({
+              colorTheme,
               state: "idle",
               text: "idle",
               showHelpText: args.showHelpText,
@@ -86,17 +86,17 @@ export const Variants: Story = {
   },
 };
 
-// variant = "success" | "aubergine"
-const renderVariant = (args: Args) => {
-  const { variant } = args;
+// colorTheme = "success" | "aubergine"
+const renderColorTheme = (args: Args) => {
+  const { colorTheme } = args;
   const checkedOrNot = [false, true, "indeterminate"];
 
-  if (!variant) {
+  if (!colorTheme) {
     return;
   }
 
   return `<li>
-    ${variant}
+    ${colorTheme}
     <ol class="focusedOrNot">
       ${states
         .map(focusState =>
@@ -138,14 +138,14 @@ const renderButton = (
     last: boolean;
   },
 ) => {
-  const { variant, focus, state, text, checked, last } = args;
+  const { colorTheme, focus, state, text, checked, last } = args;
   const className = `${focus} ${state}`;
   const lastStyles = last ? `grid-column: -1` : "";
   return `
     <kobber-checkbox-input
       style="${lastStyles}"
       class="${className}"
-      variant="${variant}"
+      color-theme="${colorTheme}"
       ${checked ? (checked === "indeterminate" ? "indeterminate" : "checked") : ""}
       ${state === "disabled" ? "disabled" : ""}
     >
@@ -161,7 +161,7 @@ export const Checkbox: Story = {
   render: args => {
     return `
       <kobber-checkbox-input 
-        variant="success" 
+        color-theme="success" 
         ${args.disabled ? "disabled" : ""}
         ${args.checked}
         name="studentoption"

--- a/packages/kobber-components/src/checkbox/checkbox-input/CheckboxInput.ts
+++ b/packages/kobber-components/src/checkbox/checkbox-input/CheckboxInput.ts
@@ -16,8 +16,8 @@ import {
   nativeCheckboxInputClassName,
   checkboxLabelClassName,
   checkboxInputName,
-  CheckboxVariant,
   checkboxWrapperClassName,
+  InputProps,
 } from "../Checkbox.core";
 import { customElement } from "../../base/utilities/customElementDecorator";
 
@@ -85,7 +85,8 @@ export class CheckboxInput extends ShoelaceElement implements ShoelaceFormContro
   /** The name of the checkbox, submitted as a name/value pair with form data. */
   @property() name = "";
 
-  @property() variant: CheckboxVariant = "success";
+  @property({ attribute: "color-theme" })
+  colorTheme: InputProps["colorTheme"] = "success";
 
   /** Disables the checkbox. */
   @property({ type: Boolean, reflect: true }) disabled = false;
@@ -217,7 +218,7 @@ export class CheckboxInput extends ShoelaceElement implements ShoelaceFormContro
 
     return html`
       <div class="${checkboxWrapperClassName}">
-        <label part="base" class=${checkboxInputName} data-variant="${this.variant}">
+        <label part="base" class=${checkboxInputName} data-color-theme="${this.colorTheme}">
           <input
             class=${[nativeCheckboxInputClassName, "visually-hidden"].join(" ")}
             type="checkbox"

--- a/packages/kobber-components/src/checkbox/checkbox-input/checkboxInput.styles.ts
+++ b/packages/kobber-components/src/checkbox/checkbox-input/checkboxInput.styles.ts
@@ -1,14 +1,14 @@
 import { css, unsafeCSS } from "lit";
 import { component, universal } from "@gyldendal/kobber-base/themes/tokens.css-variables.js";
 import {
-  checkboxVariants,
-  CheckboxClassName,
-  CheckboxVariant,
-  InputLabelClassName,
-  NativeInputClassName,
-  InputControlClassName,
-  WrapperClassName,
-  IconClassName,
+  checkboxColorThemes,
+  CheckboxClassNames,
+  CheckboxColorTheme,
+  InputLabelClassNames,
+  NativeInputClassNames,
+  InputControlClassNames,
+  WrapperClassNames,
+  IconClassNames,
   CheckboxState,
 } from "../Checkbox.core";
 import { getTypographyStyles } from "../../base/getTypographyStyles";
@@ -24,13 +24,13 @@ const createCheckboxStyles = () => {
       --icon-height: var(--icon-width);
     }
 
-    .${unsafeCSS("wrapper" satisfies WrapperClassName)} {
+    .${unsafeCSS("wrapper" satisfies WrapperClassNames)} {
       display: flex;
       flex-direction: column;
       gap: 0 var(${unsafeCSS(checkbox["container-right"].gap)});
     }
 
-    .${unsafeCSS("kobber-checkbox-input" satisfies CheckboxClassName)} {
+    .${unsafeCSS("kobber-checkbox-input" satisfies CheckboxClassNames)} {
       display: flex;
       gap: var(${unsafeCSS(checkbox.gap)});
       justify-content: start;
@@ -38,11 +38,11 @@ const createCheckboxStyles = () => {
       cursor: pointer;
       padding: var(${unsafeCSS(checkbox.padding)});
 
-      ${variantStyles()}
+      ${colorThemeStyles()}
       ${inputStates()}
     }
 
-    .${unsafeCSS("label" satisfies InputLabelClassName)} {
+    .${unsafeCSS("label" satisfies InputLabelClassNames)} {
       display: block;
       color: var(${unsafeCSS(checkbox.text.color)});
 
@@ -53,10 +53,10 @@ const createCheckboxStyles = () => {
       font-stretch: var(--typography-font-stretch);
       line-height: var(--typography-line-height);
 
-      ${unsafeCSS(getTypographyStyles("label" satisfies InputLabelClassName, "ui", "medium"))}
+      ${unsafeCSS(getTypographyStyles("label" satisfies InputLabelClassNames, "ui", "medium"))}
     }
 
-    .${unsafeCSS("control" satisfies InputControlClassName)} {
+    .${unsafeCSS("control" satisfies InputControlClassNames)} {
       width: var(${unsafeCSS(indicator.width)});
       height: var(${unsafeCSS(indicator.height)});
       display: flex;
@@ -72,34 +72,34 @@ const createCheckboxStyles = () => {
       transition: var(--transition-time) outline;
     }
 
-    .${unsafeCSS("control--shape" satisfies IconClassName)} {
+    .${unsafeCSS("control--shape" satisfies IconClassNames)} {
       display: flex;
       align-items: center;
     }
 
-    .${unsafeCSS("native-input" satisfies NativeInputClassName)} {
+    .${unsafeCSS("native-input" satisfies NativeInputClassNames)} {
       pointer-events: none;
     }
   `;
 };
 
-const variantStyles = () => {
-  const variants = checkboxVariants.flatMap(variant => {
-    const variantSelector = `&[data-variant="${variant}"]`;
+const colorThemeStyles = () => {
+  const colorThemes = checkboxColorThemes.flatMap(colorTheme => {
+    const themeSelector = `&[data-color-theme="${colorTheme}"]`;
     return css`
-      ${unsafeCSS(variantSelector)} {
-        ${statesPerVariant(variant)}
+      ${unsafeCSS(themeSelector)} {
+        ${statesPerColorTheme(colorTheme)}
       }
     `;
   });
 
-  return unsafeCSS(variants.join("\n"));
+  return unsafeCSS(colorThemes.join("\n"));
 };
 
-const statesPerVariant = (variant: CheckboxVariant) => {
-  const outlineColor = indicator.outline.color[variant];
-  const borderColor = indicator.border.color[variant];
-  const bgColor = indicator.background.color[variant];
+const statesPerColorTheme = (colorTheme: CheckboxColorTheme) => {
+  const outlineColor = indicator.outline.color[colorTheme];
+  const borderColor = indicator.border.color[colorTheme];
+  const bgColor = indicator.background.color[colorTheme];
   return css`
     & {
       --control-border-color: var(

--- a/packages/kobber-components/src/divider/Divider.stories.ts
+++ b/packages/kobber-components/src/divider/Divider.stories.ts
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/web-components-vite";
-import { DividerVariant } from "./Divider.core";
+import { DividerVariant as DividerColorVariant } from "./Divider.core";
 import "./Divider";
 import { html } from "lit";
 import "../theme-context-provider/ThemeContext";
@@ -7,13 +7,13 @@ import { init as initComponents } from "../base/init";
 
 initComponents();
 
-const variants: DividerVariant[] = ["main", "supplemental"];
+const colorVariants: DividerColorVariant[] = ["main", "supplemental"];
 
 const meta: Meta = {
   component: "kobber-divider",
   argTypes: {
-    variant: {
-      options: variants,
+    colorVariant: {
+      options: colorVariants,
       control: { type: "select" },
     },
   },
@@ -32,10 +32,10 @@ type Story = StoryObj;
 
 export const Divider: Story = {
   args: {
-    variant: variants[0],
+    colorVariant: colorVariants[0],
   },
   render: args =>
     html`<div style="height:10px; width:200px;">
-      <kobber-divider variant="${args.variant}"></kobber-divider>
+      <kobber-divider color-variant="${args.colorVariant}"></kobber-divider>
     </div>`,
 };

--- a/packages/kobber-components/src/divider/Divider.styles.ts
+++ b/packages/kobber-components/src/divider/Divider.styles.ts
@@ -14,21 +14,21 @@ const createDividerStyles = () => {
       width: 100%;
       height: 1px;
       background-color: var(--divider-background-color);
-      ${variantStyles()}
+      ${colorVariantStyles()}
     }
   `;
 };
 
-const variantStyles = () => {
-  const variants = dividerVariants.flatMap(variant => {
+const colorVariantStyles = () => {
+  const colorVariants = dividerVariants.flatMap(colorVariant => {
     return css`
-      ${unsafeCSS(`&[data-variant="${variant}"]`)} {
-        --divider-background-color: var(${unsafeCSS(dividerTokens.background.color[variant])});
+      ${unsafeCSS(`&[data-color-variant="${colorVariant}"]`)} {
+        --divider-background-color: var(${unsafeCSS(dividerTokens.background.color[colorVariant])});
       }
     `;
   });
 
-  return unsafeCSS(variants.join("\n"));
+  return unsafeCSS(colorVariants.join("\n"));
 };
 
 export const dividerStyles = createDividerStyles();

--- a/packages/kobber-components/src/divider/Divider.ts
+++ b/packages/kobber-components/src/divider/Divider.ts
@@ -7,12 +7,12 @@ import { customElement } from "../base/utilities/customElementDecorator";
 
 @customElement("kobber-divider")
 export class Divider extends KobberElement {
-  @property({ type: String })
-  variant: DividerVariant = "main";
+  @property({ type: String, attribute: "color-variant" })
+  colorVariant: DividerVariant = "main";
 
   static styles: CSSResultGroup = [dividerStyles];
 
   render() {
-    return html`<div class="${dividerClassnames().join(" ")}" data-variant="${this.variant}"></div> `;
+    return html`<div class="${dividerClassnames().join(" ")}" data-color-variant="${this.colorVariant}"></div> `;
   }
 }

--- a/packages/kobber-components/src/radio/Radio.core.ts
+++ b/packages/kobber-components/src/radio/Radio.core.ts
@@ -1,4 +1,5 @@
 import { component } from "@gyldendal/kobber-base/themes/tokens.css-variables.js";
+import { objectKeys } from "../base/utilities/objectKeys";
 
 export const radioInputName = "kobber-radio-input";
 export const radioInputControlName = "kobber-radio-input-control";
@@ -34,7 +35,7 @@ export type GroupProps = {
 export type InputProps = {
   checked?: boolean;
   disabled?: boolean;
-  variant?: InputVariant;
+  colorTheme?: InputColorTheme;
   href?: string;
 };
 
@@ -44,14 +45,15 @@ type InputComputedProps = {
 
 export type ControlProps = {
   checked?: boolean;
-  variant: InputVariant;
+  colorTheme: InputColorTheme;
 };
 
-export type GroupClassName = typeof radioGroupName;
-export type InputLabelClassName = typeof radioInputLabelClassName;
-export type InputControlClassName = typeof radioInputControlName;
+export type GroupClassNames = typeof radioGroupName;
+export type InputLabelClassNames = typeof radioInputLabelClassName;
+export type InputControlClassNames = typeof radioInputControlName;
 export type InputControlPartNames = typeof radioInputControlPartName | typeof radioInputControlPartNameChecked;
 export type InputClassNames = typeof radioInputName | typeof radioInputAsLinkClassName;
-export type InputVariant = keyof (typeof radioTokens)["indicator"]["border"]["color"];
 
-export const inputVariants = Object.keys(radioTokens.indicator.border.color) as InputVariant[];
+export type InputColorTheme = (typeof inputColorThemes)[number];
+
+export const inputColorThemes = objectKeys(radioTokens.indicator.border.color);

--- a/packages/kobber-components/src/radio/Radio.mdx
+++ b/packages/kobber-components/src/radio/Radio.mdx
@@ -25,8 +25,8 @@ Keyboard navigation: Use tab to reach the radio group, and <a href="https://www.
 </details>
 
 <figure>
-  <figcaption>Kobber Radio Input Variants (only static examples, not intended for interaction)</figcaption>
-  <Story of={RadioStories.Variants} />
+  <figcaption>Kobber Radio Input Themes (only static examples, not intended for interaction)</figcaption>
+  <Story of={RadioStories.Themes} />
 </figure>
 
 <figure>

--- a/packages/kobber-components/src/radio/Radio.stories.ts
+++ b/packages/kobber-components/src/radio/Radio.stories.ts
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from "@storybook/web-components-vite";
 import "./radio-input/RadioInput";
 import "./radio-group/RadioGroup";
 import { primitives } from "@gyldendal/kobber-base/themes/default/tokens.js";
-import { inputVariants, InputProps, radioInputName } from "./Radio.core";
+import { inputColorThemes, InputProps, radioInputName } from "./Radio.core";
 import "../text/heading/Heading";
 import "../theme-context-provider/ThemeContext";
 import { init as initComponents } from "../base/init";
@@ -46,7 +46,7 @@ const meta: Meta<Args> = {
 export default meta;
 type Story = StoryObj;
 
-export const Variants: Story = {
+export const Themes: Story = {
   render: args => {
     return `
       <style>
@@ -84,10 +84,10 @@ export const Variants: Story = {
       </style>
 
       <ol>
-        ${inputVariants
-          .map(variant =>
-            renderVariant({
-              variant,
+        ${inputColorThemes
+          .map(colorTheme =>
+            renderColorTheme({
+              colorTheme,
               state: "idle",
               text: "idle",
               link: false,
@@ -103,16 +103,16 @@ export const Variants: Story = {
   },
 };
 
-// variant = "success" | "aubergine"
-const renderVariant = (args: Args) => {
-  const { variant } = args;
+// colorTheme = "success" | "aubergine"
+const renderColorTheme = (args: Args) => {
+  const { colorTheme } = args;
   const checkedOrNot = [false, true];
 
-  if (!variant) {
+  if (!colorTheme) {
     return;
   }
 
-  return `<li>${variant}
+  return `<li>${colorTheme}
   <ol class="focusedOrNot">${states
     .map(focusState =>
       Object.keys(focusState).map(key => {
@@ -151,14 +151,14 @@ const renderButton = (
     last: boolean;
   },
 ) => {
-  const { variant, focus, state, text, link, checked, last } = args;
+  const { colorTheme, focus, state, text, link, checked, last } = args;
   const className = `${focus} ${state}`;
   const lastStyles = last ? `grid-column: -1` : "";
   return `
 <kobber-radio-input 
   style="${lastStyles}"
   class="${className}" 
-  variant="${variant}" 
+  colorTheme="${colorTheme}" 
   ${checked ? "checked" : ""} 
   ${state === "disabled" ? "disabled" : ""} 
   ${link ? "href='#'" : ""}>
@@ -208,17 +208,17 @@ export const GNOExample: Story = {
         </p>
         
           <kobber-radio-input value="hardcover" ${args.link ? `href="#format-innbundet"` : ""}
-             variant="${args.variant}"><div>Innbundet – <em style="text-wrap: nowrap">kr 2 339,-</em></div></kobber-radio-input
+             color-theme="${args.colorTheme}"><div>Innbundet – <em style="text-wrap: nowrap">kr 2 339,-</em></div></kobber-radio-input
           >
           <kobber-radio-input value="pocket" ${args.link ? `href="#format-pocket"` : ""} disabled
-             variant="${args.variant}"><div>Pocket – <em style="text-wrap: nowrap">kr 339,-</em><p class="alert">Utsolgt</p></div></kobber-radio-input
+             color-theme="${args.colorTheme}"><div>Pocket – <em style="text-wrap: nowrap">kr 339,-</em><p class="alert">Utsolgt</p></div></kobber-radio-input
           >
           <kobber-radio-input value="ebook" ${args.link ? `href="#format-ebok"` : ""}
-             variant="${args.variant}"><div>Ebok (med label som er så lang <br />
+             color-theme="${args.colorTheme}"><div>Ebok (med label som er så lang <br />
             at den går over flere linjer) – <em style="text-wrap: nowrap">kr 39,-</em></div></kobber-radio-input
           >
           <kobber-radio-input value="audiobook" ${args.link ? `href="#format-lydbok"` : ""}
-             variant="${args.variant}"><div>Lydbok – <em style="text-wrap: nowrap">kr 339,-</em></div></kobber-radio-input
+             color-theme="${args.colorTheme}"><div>Lydbok – <em style="text-wrap: nowrap">kr 339,-</em></div></kobber-radio-input
           >
           ${args.showHelpText ? helpTextElement : ""}
         </kobber-radio-group>
@@ -226,9 +226,9 @@ export const GNOExample: Story = {
     `;
   },
   argTypes: {
-    variant: {
-      name: "variant (visible only in hover and active states)",
-      options: inputVariants,
+    colorTheme: {
+      name: "color-theme (visible only in hover and active states)",
+      options: inputColorThemes,
       control: { type: "radio" },
     },
     link: {
@@ -247,7 +247,7 @@ export const GNOExample: Story = {
     currentValue: "ebook",
     direction: "horizontal",
     showHelpText: true,
-    variant: inputVariants[0],
+    colorTheme: inputColorThemes[0],
   },
 };
 
@@ -276,28 +276,28 @@ export const SkolestudioExamples: Story = {
       <div class="wrapper-theme">
         <kobber-radio-group direction="horizontal" current-value="no-bm">
         <p slot="label">Målform</p>
-          <kobber-radio-input value="no-bm" variant="${args.variant}">Bokmål</kobber-radio-input>
-          <kobber-radio-input value="no-nn" variant="${args.variant}">Nynorsk</kobber-radio-input>
+          <kobber-radio-input value="no-bm" color-theme="${args.colorTheme}">Bokmål</kobber-radio-input>
+          <kobber-radio-input value="no-nn" color-theme="${args.colorTheme}">Nynorsk</kobber-radio-input>
         </kobber-radio-group>
 
         <kobber-radio-group direction="horizontal" current-value="level11-13">
         <p slot="label">Trinn</p>
-          <kobber-radio-input value="level1-7" variant="${args.variant}">1.–7. trinn</kobber-radio-input>
-          <kobber-radio-input value="level8-10" variant="${args.variant}">8.–10. trinn</kobber-radio-input>
-          <kobber-radio-input value="level11-13" variant="${args.variant}">VG1–VG3</kobber-radio-input>
+          <kobber-radio-input value="level1-7" color-theme="${args.colorTheme}">1.–7. trinn</kobber-radio-input>
+          <kobber-radio-input value="level8-10" color-theme="${args.colorTheme}">8.–10. trinn</kobber-radio-input>
+          <kobber-radio-input value="level11-13" color-theme="${args.colorTheme}">VG1–VG3</kobber-radio-input>
         </kobber-radio-group>
       </div>
     `;
   },
   argTypes: {
-    variant: {
-      name: "variant (visible only in hover and active states)",
-      options: inputVariants,
+    colorTheme: {
+      name: "color-theme (visible only in hover and active states)",
+      options: inputColorThemes,
       control: { type: "radio" },
     },
   },
   args: {
-    variant: inputVariants[0],
+    colorTheme: inputColorThemes[0],
   },
   parameters: {
     actions: {

--- a/packages/kobber-components/src/radio/radio-group/RadioGroup.styles.ts
+++ b/packages/kobber-components/src/radio/radio-group/RadioGroup.styles.ts
@@ -1,5 +1,5 @@
 import { css, unsafeCSS } from "lit";
-import { GroupClassName } from "../Radio.core";
+import { GroupClassNames } from "../Radio.core";
 
 /**
  * Shared styles, used in web component, React and CSS module.
@@ -7,7 +7,7 @@ import { GroupClassName } from "../Radio.core";
  */
 const createRadioGroupStyles = () => {
   return css`
-    .${unsafeCSS("kobber-radio-group" satisfies GroupClassName)} {
+    .${unsafeCSS("kobber-radio-group" satisfies GroupClassNames)} {
       border: none;
     }
 

--- a/packages/kobber-components/src/radio/radio-input-control/RadioInputControl.styles.ts
+++ b/packages/kobber-components/src/radio/radio-input-control/RadioInputControl.styles.ts
@@ -1,6 +1,6 @@
 import { css, unsafeCSS } from "lit";
 import { component } from "@gyldendal/kobber-base/themes/tokens.css-variables.js";
-import { inputVariants, InputControlClassName } from "../Radio.core";
+import { inputColorThemes, InputControlClassNames } from "../Radio.core";
 
 const indicatorStyles = component._radiobutton.indicator;
 const inputColor = indicatorStyles.border.color;
@@ -15,7 +15,7 @@ const createInputControlStyles = () => {
       --icon-width: var(${unsafeCSS(indicatorStyles.shape.width)});
     }
 
-    .${unsafeCSS("kobber-radio-input-control" satisfies InputControlClassName)} {
+    .${unsafeCSS("kobber-radio-input-control" satisfies InputControlClassNames)} {
       margin-top: 0.3em; /* A top margin emulates label being vertically aligned with idle input control, but not when multiple lines. */
       width: var(--icon-wrapper-width);
       height: var(--icon-wrapper-height);
@@ -25,17 +25,17 @@ const createInputControlStyles = () => {
       border-radius: 50%;
       transition: var(--transition-time) outline;
 
-      ${buttonVariantStyles()}
+      ${buttonColorThemeStyles()}
     }
   `;
 };
 
-const buttonVariantStyles = () => {
-  const variableClasses = inputVariants.flatMap(variant => {
-    const variantSelector = `&[data-variant="${variant}"]`;
-    const borderColor = inputColor[variant];
+const buttonColorThemeStyles = () => {
+  const variableClasses = inputColorThemes.flatMap(colorTheme => {
+    const colorThemeSelector = `&[data-color-theme="${colorTheme}"]`;
+    const borderColor = inputColor[colorTheme];
     return css`
-      ${unsafeCSS(variantSelector)} {
+      ${unsafeCSS(colorThemeSelector)} {
         --control-color: var(${unsafeCSS(borderColor)});
       }
     `;

--- a/packages/kobber-components/src/radio/radio-input-control/RadioInputControl.ts
+++ b/packages/kobber-components/src/radio/radio-input-control/RadioInputControl.ts
@@ -6,7 +6,7 @@ import { radioInputControlStyles } from "./RadioInputControl.styles";
 import type { CSSResultGroup } from "lit";
 import "../../base/internal/icons";
 import {
-  InputVariant,
+  InputColorTheme,
   radioInputControlPartNameChecked,
   radioInputControlName,
   radioInputControlPartName,
@@ -29,8 +29,8 @@ export class RadioInputControl extends ShoelaceElement implements ControlProps {
 
   @property({ type: Boolean, reflect: true }) checked = false;
 
-  @property()
-  variant: InputVariant = "success";
+  @property({ attribute: "color-theme" })
+  colorTheme: ControlProps["colorTheme"] = "success";
 
   connectedCallback() {
     super.connectedCallback();
@@ -40,7 +40,7 @@ export class RadioInputControl extends ShoelaceElement implements ControlProps {
     return html`
       <div
         class="${radioInputControlName}"
-        data-variant="${this.variant}"
+        data-color-theme="${this.colorTheme}"
         part="${`${radioInputControlPartName} ${this.checked ? radioInputControlPartNameChecked : ""}`}"
       >
         ${this.checked ? html` <icon-form_radio part="checked-icon" /> ` : ""}

--- a/packages/kobber-components/src/radio/radio-input/RadioInput.styles.ts
+++ b/packages/kobber-components/src/radio/radio-input/RadioInput.styles.ts
@@ -1,10 +1,10 @@
 import { css, unsafeCSS } from "lit";
 import { component, universal } from "@gyldendal/kobber-base/themes/tokens.css-variables.js";
 import {
-  inputVariants,
+  inputColorThemes,
   InputClassNames,
-  InputVariant,
-  InputLabelClassName,
+  InputColorTheme,
+  InputLabelClassNames,
   InputControlPartNames,
 } from "../Radio.core";
 import { getTypographyStyles } from "../../base/getTypographyStyles";
@@ -25,7 +25,7 @@ const createInputStyles = () => {
       cursor: pointer;
       padding: var(${unsafeCSS(inputStyles.padding)});
 
-      ${inputVariantStyles()}
+      ${inputColorThemeStyles()}
       ${inputStates()}
       
       &.${unsafeCSS("input--as-link" satisfies InputClassNames)} {
@@ -33,7 +33,7 @@ const createInputStyles = () => {
       }
     }
 
-    .${unsafeCSS("label" satisfies InputLabelClassName)} {
+    .${unsafeCSS("label" satisfies InputLabelClassNames)} {
       display: block;
       color: var(${unsafeCSS(inputStyles.text.color)});
 
@@ -44,26 +44,26 @@ const createInputStyles = () => {
       font-stretch: var(--typography-font-stretch);
       line-height: var(--typography-line-height);
 
-      ${unsafeCSS(getTypographyStyles("label" satisfies InputLabelClassName, "ui", "medium"))}
+      ${unsafeCSS(getTypographyStyles("label" satisfies InputLabelClassNames, "ui", "medium"))}
     }
   `;
 };
 
-const inputVariantStyles = () => {
-  const variantClasses = inputVariants.flatMap(variant => {
-    const variantSelector = `&[data-variant="${variant}"]`;
+const inputColorThemeStyles = () => {
+  const colorThemeClasses = inputColorThemes.flatMap(colorTheme => {
+    const colorThemeSelector = `&[data-color-theme="${colorTheme}"]`;
     return css`
-      ${unsafeCSS(variantSelector)} {
-        ${inputStatesPerVariant(variant)}
+      ${unsafeCSS(colorThemeSelector)} {
+        ${inputStatesPerColorTheme(colorTheme)}
       }
     `;
   });
 
-  return unsafeCSS(variantClasses.join("\n"));
+  return unsafeCSS(colorThemeClasses.join("\n"));
 };
 
-const inputStatesPerVariant = (variant: InputVariant) => {
-  const outlineColor = inputStyles.indicator.outline.color[variant];
+const inputStatesPerColorTheme = (colorTheme: InputColorTheme) => {
+  const outlineColor = inputStyles.indicator.outline.color[colorTheme];
   return css`
     &.hover,
     :host(:hover) & {

--- a/packages/kobber-components/src/radio/radio-input/RadioInput.ts
+++ b/packages/kobber-components/src/radio/radio-input/RadioInput.ts
@@ -8,7 +8,6 @@ import type { CSSResultGroup } from "lit";
 import {
   inputClassNames,
   radioInputName,
-  InputVariant,
   radioInputLabelClassName,
   InputProps,
   radioInputControlName,
@@ -40,7 +39,8 @@ export class RadioInput extends ShoelaceElement implements InputProps {
   /** The radio's value. When selected, the radio group will receive this value. */
   @property() value: string = "";
 
-  @property() variant: InputVariant = "success";
+  @property({ attribute: "color-theme" })
+  colorTheme?: InputProps["colorTheme"] = "success";
 
   /** Disables the radio. */
   @property({ type: Boolean, reflect: true }) disabled = false;
@@ -113,7 +113,7 @@ export class RadioInput extends ShoelaceElement implements InputProps {
           }),
           this.className,
         ].join(" ")}
-        data-variant="${this.variant}"
+        data-color-theme="${this.colorTheme}"
         ?disabled="${this.disabled}"
         href="${this.href}"
         usedInOtherInteractive
@@ -121,7 +121,7 @@ export class RadioInput extends ShoelaceElement implements InputProps {
       >
         <${radioInputControlElement}
           ?checked="${this.checked}"
-          variant="${this.variant}"
+          color-theme="${this.colorTheme}"
           slot="icon"
         ></${radioInputControlElement}>
         <slot part="label"></slot>
@@ -135,9 +135,9 @@ export class RadioInput extends ShoelaceElement implements InputProps {
           }),
           this.className,
         ].join(" ")}
-        data-variant="${this.variant}"
+        data-color-theme="${this.colorTheme}"
       >
-        <${radioInputControlElement} ?checked="${this.checked}" variant="${this.variant}"></${radioInputControlElement}>
+        <${radioInputControlElement} ?checked="${this.checked}" color-theme="${this.colorTheme}"></${radioInputControlElement}>
         <slot part="label" class="${radioInputLabelClassName}"></slot>
       </div>
     `;

--- a/packages/kobber-components/src/text/Text.stories.ts
+++ b/packages/kobber-components/src/text/Text.stories.ts
@@ -4,7 +4,7 @@ import "./text-wrapper/TextWrapper";
 import "./heading/Heading";
 import "./ingress/Ingress";
 import "./text-link/TextLink";
-import { headingElements, headingSizes, headingVariants } from "./heading/Heading.core";
+import { headingElements, headingSizes, headingColorLevels } from "./heading/Heading.core";
 import "@gyldendal/kobber-icons/web-components";
 import { init as initComponents } from "../base/init";
 import { init as initIcons } from "@gyldendal/kobber-icons/init";
@@ -136,15 +136,15 @@ export const Heading: Story = {
                         padding: 1em;"
                 >
                   <em style="grid-area: element-and-size;">${element} - ${size}</em>
-                  ${headingVariants.map(
-                    variant => html`
-                      <p style="grid-area: ${variant};">${variant}</p>
+                  ${headingColorLevels.map(
+                    colorVariant => html`
+                      <p style="grid-area: ${colorVariant};">${colorVariant}</p>
                       <kobber-heading
                         level="${args.h1 ? "h1" : "h2"}"
                         element="${element}"
-                        variant="${variant}"
+                        color-variant="${colorVariant}"
                         size="${size}"
-                        style="grid-area: sample-${variant};"
+                        style="grid-area: sample-${colorVariant};"
                       >
                         ${text(args.text || "Heading")}
                       </kobber-heading>

--- a/packages/kobber-components/src/text/heading/Heading.core.ts
+++ b/packages/kobber-components/src/text/heading/Heading.core.ts
@@ -1,4 +1,5 @@
 import { universal } from "@gyldendal/kobber-base/themes/tokens.css-variables.js";
+import { objectKeys } from "../../base/utilities/objectKeys";
 
 const headingTokens = universal.text;
 
@@ -16,20 +17,18 @@ export const sanitizeHeadingLevel = (level: HeadingLevel | undefined): HeadingLe
 export type HeadingProps = {
   level?: HeadingLevel;
   element?: HeadingElement;
-  variant?: HeadingVariant;
+  colorLevel?: HeadingColorLevel;
   size?: HeadingSize;
 };
 
 type HeadingClassNames = typeof headingName;
 type HeadingLevel = (typeof headingLevels)[number];
 type HeadingElement = (typeof headingElements)[number];
-type HeadingVariant = (typeof headingVariants)[number];
+type HeadingColorLevel = (typeof headingColorLevels)[number];
 type HeadingSize = (typeof headingSizes)[number];
 
 const headingLevels = ["h1", "h2", "h3", "h4", "h5", "h6", "span", "div"] as const;
 
-export const headingElements = ["display", "heading", "title"] satisfies (keyof typeof headingTokens.primary.size)[];
-
-export const headingVariants = ["primary", "secondary"] satisfies (keyof typeof headingTokens)[];
-
-export const headingSizes = ["medium", "small"] satisfies (keyof typeof headingTokens.primary.size.heading)[];
+export const headingElements = objectKeys(headingTokens.primary.size);
+export const headingColorLevels = objectKeys(headingTokens);
+export const headingSizes = objectKeys(headingTokens.primary.size.display);

--- a/packages/kobber-components/src/text/heading/Heading.styles.ts
+++ b/packages/kobber-components/src/text/heading/Heading.styles.ts
@@ -1,6 +1,6 @@
 import { css, unsafeCSS } from "lit";
 import { component } from "@gyldendal/kobber-base/themes/tokens.css-variables.js";
-import { headingName, headingElements, headingSizes, headingVariants } from "./Heading.core";
+import { headingName, headingElements, headingSizes, headingColorLevels } from "./Heading.core";
 import { resetHeading } from "../../base/styles/reset.styles";
 import { getTypographyStyles } from "../../base/getTypographyStyles";
 
@@ -46,13 +46,13 @@ const typographyStyles = () => {
       headingElements
         .flatMap(
           element =>
-            `&[data-element="${element}"] {${headingVariants
+            `&[data-element="${element}"] {${headingColorLevels
               .flatMap(
-                variant =>
-                  `&[data-variant="${variant}"] {${headingSizes
+                colorLevel =>
+                  `&[data-color-level="${colorLevel}"] {${headingSizes
                     .flatMap(size => {
                       return `&[data-size="${size}"] {
-                  ${getTypographyStyles(element, variant, size)}}`;
+                  ${getTypographyStyles(element, colorLevel, size)}}`;
                     })
                     .join("")}}`,
               )

--- a/packages/kobber-components/src/text/heading/Heading.ts
+++ b/packages/kobber-components/src/text/heading/Heading.ts
@@ -10,16 +10,16 @@ import { customElement } from "../../base/utilities/customElementDecorator";
 export class Heading extends LitElement implements HeadingProps {
   static styles: CSSResultGroup = [componentStyles, headingStyles];
 
-  @property({ type: String })
+  @property()
   level: HeadingProps["level"];
 
-  @property({ type: String })
+  @property()
   element: HeadingProps["element"] = "display";
 
-  @property({ type: String })
-  variant: HeadingProps["variant"] = "primary";
+  @property({ attribute: "color-level" })
+  colorLevel: HeadingProps["colorLevel"] = "primary";
 
-  @property({ type: String })
+  @property()
   size: HeadingProps["size"] = "small";
 
   render() {
@@ -29,7 +29,7 @@ export class Heading extends LitElement implements HeadingProps {
       <${unsafeStatic(tag)} class="${headingClassNames().join(" ")}"
         data-level="${this.level}"
         data-element="${this.element}"
-        data-variant="${this.variant}"
+        data-color-level="${this.colorLevel}"
         data-size="${this.size}"
       >
         <slot></slot>


### PR DESCRIPTION
- Naming: Names from token colors are always prefixed with "color".
- Type-checking: Token value listings are now the single source of token truth. Our type definitions should use the listings' type, instead of looking up types within the token file. By looking up types themselves, our type definitions may, by error, be unrelated to those of the token value listings. If so, we have type errors that the code does not alert us of.
- Component properties: All components' attributes (where applicable) now looks up type from their Props type. This is more readable than stating the attributes types separately from the Props type.
- Other cleanus, like removing unused imports.