### PR TITLE
Button: Split property "variant" into simpler properties

### DIFF
--- a/apps/docs/app/(web)/(routes)/_draftTools/DarkModeTrigger.tsx
+++ b/apps/docs/app/(web)/(routes)/_draftTools/DarkModeTrigger.tsx
@@ -20,7 +20,9 @@ export const DarkModeTrigger = () => {
 
   return (
     <KobberButton
-      variant="brand-primary-main"
+      color-theme="brand"
+      color-level="primary"
+      color-variant="main"
       className={kobberTheme}
       onClick={handleClick}
       title={`Skru ${colorScheme === "dark" ? "av" : "på"} dark mode`}

--- a/apps/docs/app/(web)/(routes)/_draftTools/DraftTools.tsx
+++ b/apps/docs/app/(web)/(routes)/_draftTools/DraftTools.tsx
@@ -23,7 +23,9 @@ export const DraftTools = ({ pageId }: Props) => {
             <DarkModeTrigger />
             <TokenMixer />
             <KobberButton
-              variant="vacation-primary-main"
+              color-theme="vacation"
+              color-level="primary"
+              color-variant="main"
               title="Åpne studio"
               href={pageId ? `/studio/structure/page;${pageId}` : "/studio/structure/homePage"}
             >
@@ -36,7 +38,9 @@ export const DraftTools = ({ pageId }: Props) => {
 
         <KobberButton
           className={styles["trigger"]}
-          variant="brand-secondary-main"
+          color-theme="brand"
+          color-level="secondary"
+          color-variant="main"
           onClick={() => setOpen(!open)}
           title={`${open ? "Lukk" : "Åpne"} draft tools`}
         >

--- a/apps/docs/app/(web)/(routes)/_draftTools/TokenMixer.tsx
+++ b/apps/docs/app/(web)/(routes)/_draftTools/TokenMixer.tsx
@@ -13,7 +13,13 @@ export const TokenMixer = () => {
   return (
     <>
       {show && <TokenOverlay onClose={() => setShow(false)} />}
-      <KobberButton variant="brand-primary-main" title="Token mixer" onClick={handleClick}>
+      <KobberButton
+        color-theme="brand"
+        color-level="primary"
+        color-variant="main"
+        title="Token mixer"
+        onClick={handleClick}
+      >
         <div slot="icon">
           <Settings2Icon />
         </div>
@@ -70,13 +76,28 @@ const TokenOverlay = ({ onClose }: { onClose: () => void }) => {
           onChange={(e) => setLocalCss(e.target.value)}
         />
         <div className={styles["token-mixer-controls"]}>
-          <KobberButton variant="brand-primary-main" onClick={handleSaveCss}>
+          <KobberButton
+            color-theme="brand"
+            color-level="primary"
+            color-variant="main"
+            onClick={handleSaveCss}
+          >
             Save
           </KobberButton>
-          <KobberButton variant="brand-secondary-main" onClick={handleResetCss}>
+          <KobberButton
+            color-theme="brand"
+            color-level="secondary"
+            color-variant="main"
+            onClick={handleResetCss}
+          >
             Reset
           </KobberButton>
-          <KobberButton variant="brand-tertiary-main" onClick={onClose}>
+          <KobberButton
+            color-theme="brand"
+            color-level="tertiary"
+            color-variant="main"
+            onClick={onClose}
+          >
             Close
           </KobberButton>
         </div>

--- a/apps/docs/components/global/login-button.tsx
+++ b/apps/docs/components/global/login-button.tsx
@@ -31,7 +31,9 @@ export const LoginButton = (props: Props) => {
     <div className={styles["wrapper"]}>
       <KobberButton
         fullWidth
-        variant={cta ? "brand-primary-main" : "brand-secondary-main"}
+        color-theme="brand"
+        color-level={cta ? "primary" : "secondary"}
+        color-variant="main"
         onClick={status === "unauthenticated" ? handleLogin : handleLogout}
       >
         <Login className={styles["icon"]} slot="icon" />

--- a/apps/docs/components/navigation/small-screen-nav/small-screen-nav-trigger.tsx
+++ b/apps/docs/components/navigation/small-screen-nav/small-screen-nav-trigger.tsx
@@ -34,13 +34,25 @@ export const SmallScreenNavTrigger = () => {
   }, [isOpen])
 
   return isOpen ? (
-    <KobberButton variant={"brand-primary-main"} onClick={onClose} aria-label={"Lukk meny"}>
+    <KobberButton
+      color-theme="brand"
+      color-level="primary"
+      color-variant="main"
+      onClick={onClose}
+      aria-label={"Lukk meny"}
+    >
       <div slot="icon">
         <X size={20} />
       </div>
     </KobberButton>
   ) : (
-    <KobberButton variant={"brand-secondary-main"} onClick={onOpen} aria-label={"Åpne meny"}>
+    <KobberButton
+      color-theme="brand"
+      color-level="secondary"
+      color-variant="main"
+      onClick={onOpen}
+      aria-label={"Åpne meny"}
+    >
       <div slot="icon">
         <Menu size={20} />
       </div>

--- a/apps/docs/components/page-builder/sections/color-list/color-list-block-item.tsx
+++ b/apps/docs/components/page-builder/sections/color-list/color-list-block-item.tsx
@@ -62,7 +62,9 @@ export const ColorListItem = (props: ItemProps) => {
                       } as React.CSSProperties
                     }
                     disabled
-                    variant="brand-tertiary-main"
+                    color-theme="brand"
+                    color-level="tertiary"
+                    color-variant="main"
                   >
                     <Check slot="icon" />
                     Kopiert
@@ -76,7 +78,9 @@ export const ColorListItem = (props: ItemProps) => {
                         height: "1.5rem",
                       } as React.CSSProperties
                     }
-                    variant="brand-tertiary-main"
+                    color-theme="brand"
+                    color-level="tertiary"
+                    color-variant="main"
                     onClick={() => copyToClipboard(color.value)}
                   >
                     Kopier

--- a/packages/kobber-components/src/base/internal/buttonUtils.ts
+++ b/packages/kobber-components/src/base/internal/buttonUtils.ts
@@ -1,0 +1,34 @@
+import { ButtonType, ButtonColorTheme, ButtonColorVariant, ButtonColorLevel } from "../../button/Button.core";
+
+export const isValidPropCombination = (
+  buttonType: ButtonType,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  component: any,
+  colorTheme: ButtonColorTheme,
+  colorVariant: ButtonColorVariant,
+  colorLevel?: ButtonColorLevel,
+) => {
+  let textColor, backgroundColor, borderColor;
+
+  if (colorLevel) {
+    textColor =
+      component[buttonType].text.color?.[colorTheme]?.[colorLevel!]?.[colorVariant] ??
+      component[buttonType].text.color?.[colorTheme]?.[colorLevel!];
+    backgroundColor = component[buttonType].background?.color?.[colorTheme]?.[colorLevel!]?.[colorVariant];
+    borderColor = component[buttonType]?.border?.color?.[colorTheme]?.[colorLevel!]?.[colorVariant];
+  } else {
+    textColor = component[buttonType].text.color?.[colorTheme];
+    backgroundColor = component[buttonType].background.color[colorTheme][colorVariant];
+    borderColor = component[buttonType]?.border?.color?.[colorTheme][colorVariant];
+  }
+
+  if (
+    typeof textColor === "string" ||
+    typeof backgroundColor?.fallback === "string" ||
+    typeof borderColor?.active === "string"
+  ) {
+    return true;
+  }
+  console.log("Invalid prop combination");
+  return false;
+};

--- a/packages/kobber-components/src/base/utilities/join.ts
+++ b/packages/kobber-components/src/base/utilities/join.ts
@@ -1,9 +1,0 @@
-export const concat3 = <A extends string, B extends string, C extends string>(aList: A[], bList: B[], cList: C[]) =>
-  aList.flatMap(a => bList.flatMap(b => cList.map(c => `${a}-${b}-${c}` as Join3<A, B, C>)));
-
-type Join3<A extends string, B extends string, C extends string> = `${A}-${B}-${C}`;
-
-export const concat2 = <A extends string, B extends string>(aList: A[], bList: B[]) =>
-  aList.flatMap(a => bList.map(b => `${a}-${b}` as Join2<A, B>));
-
-type Join2<A extends string, B extends string> = `${A}-${B}`;

--- a/packages/kobber-components/src/button/Button.core.ts
+++ b/packages/kobber-components/src/button/Button.core.ts
@@ -1,11 +1,37 @@
 import { component } from "@gyldendal/kobber-base/themes/tokens.css-variables.js";
 import { objectKeys } from "../base/utilities/objectKeys";
-import { concat2, concat3 } from "../base/utilities/join";
+
+type ButtonComputedProps = {
+  hasIcon?: boolean;
+  iconOnly?: boolean;
+  isLink?: boolean;
+};
+
+const buttonDefaultColorThemes = objectKeys(component.button.background.color);
+const buttonDefaultColorLevels = [
+  ...objectKeys(component.button.background.color.brand),
+  ...objectKeys(component.button.border.color.brand),
+];
+const buttonDefaultColorVariants = objectKeys(component.button.background.color.brand.secondary);
+
+const buttonUiColorThemes = objectKeys(component["ui-button"]["background"]["color"]);
+const buttonUiColorVariants = objectKeys(component["ui-button"]["background"]["color"].informative);
+
+const buttonThemeColorThemes = objectKeys(component["theme-button"]["background"]["color"]);
+const buttonThemeColorLevels = [
+  ...objectKeys(component["theme-button"].background.color.carmine),
+  ...objectKeys(component["theme-button"].border.color.carmine),
+];
+const buttonThemeColorVariants = objectKeys(component["theme-button"]["background"]["color"].carmine.primary);
+
+type ButtonColorProperties = {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  [key in ButtonType]: any[];
+};
 
 export const buttonName = "kobber-button";
 
 export const buttonClassNames = ({
-  variant = "brand-primary-main",
   hasIcon = false,
   iconOnly = false,
   iconFirst = false,
@@ -36,26 +62,38 @@ export const buttonClassNames = ({
     conditionalClassNames.push("kobber-button--used-in-other-interactive");
   }
 
-  return [buttonName, variant, ...conditionalClassNames];
+  return [buttonName, ...conditionalClassNames];
 };
 
 export type ButtonProps = {
+  colorTheme?: ButtonColorTheme;
+  colorLevel?: ButtonColorLevel;
+  colorVariant?: ButtonColorVariant;
   iconFirst?: boolean;
   fullWidth?: boolean;
   usedInOtherInteractive?: boolean;
   href?: string;
+  type?: ButtonType;
   target?: "_blank" | "_parent" | "_self" | "_top";
-} & { variant?: ButtonDefaultProps | ButtonThemeProps | ButtonUiProps };
-
-export type ButtonComputedProps = {
-  hasIcon?: boolean;
-  iconOnly?: boolean;
-  isLink?: boolean;
 };
+
+export const buttonTypes: ButtonType[] = ["button", "ui-button", "theme-button"];
+export type ButtonType = "button" | "ui-button" | "theme-button";
+
+export type ButtonColorLevel = (typeof buttonDefaultColorLevels)[number] | (typeof buttonThemeColorLevels)[number];
+
+export type ButtonColorTheme =
+  | (typeof buttonDefaultColorThemes)[number]
+  | (typeof buttonUiColorThemes)[number]
+  | (typeof buttonThemeColorThemes)[number];
+
+export type ButtonColorVariant =
+  | (typeof buttonDefaultColorVariants)[number]
+  | (typeof buttonUiColorVariants)[number]
+  | (typeof buttonThemeColorVariants)[number];
 
 export type ButtonClassNames =
   | typeof buttonName
-  | ButtonProps["variant"]
   | "kobber-button--icon"
   | "kobber-button--icon-only"
   | "kobber-button--icon-left"
@@ -64,33 +102,20 @@ export type ButtonClassNames =
   | "kobber-button--link"
   | "kobber-button--inlined";
 
-type ButtonDefaultProps = (typeof buttonDefaultProps)[number];
-export const buttonDefaultColors = objectKeys(component.button.background.color);
-export const buttonDefaultLevels = [
-  ...objectKeys(component.button.background.color.brand),
-  ...objectKeys(component.button.border.color.brand),
-];
-export const buttonDefaultVariants = objectKeys(component.button.background.color.brand.secondary);
-export const buttonDefaultProps = buttonDefaultColors.flatMap(color =>
-  buttonDefaultLevels.flatMap(level => {
-    if (level === "primary" || color === "neutral") {
-      return `${color}-${level}-main` as const;
-    }
+export const buttonColorLevels: ButtonColorProperties = {
+  button: buttonDefaultColorLevels,
+  "ui-button": [],
+  "theme-button": buttonThemeColorLevels,
+};
 
-    return buttonDefaultVariants.map(variant => `${color}-${level}-${variant}` as const);
-  }),
-);
+export const buttonColorThemes: ButtonColorProperties = {
+  button: buttonDefaultColorThemes,
+  "ui-button": buttonUiColorThemes,
+  "theme-button": buttonThemeColorThemes,
+};
 
-type ButtonUiProps = (typeof buttonUiProps)[number];
-export const buttonUiColors = objectKeys(component["ui-button"]["background"]["color"]);
-export const buttonUiVariants = objectKeys(component["ui-button"]["background"]["color"].informative);
-export const buttonUiProps = concat2(buttonUiColors, buttonUiVariants);
-
-type ButtonThemeProps = (typeof buttonThemeProps)[number];
-export const buttonThemeColors = objectKeys(component["theme-button"]["background"]["color"]);
-export const buttonThemeLevels = [
-  ...objectKeys(component["theme-button"].background.color.carmine),
-  ...objectKeys(component["theme-button"].border.color.carmine),
-];
-export const buttonThemeVariants = objectKeys(component["theme-button"]["background"]["color"].carmine.primary);
-export const buttonThemeProps = concat3(buttonThemeColors, buttonThemeLevels, buttonThemeVariants);
+export const buttonColorVariants: ButtonColorProperties = {
+  button: buttonDefaultColorVariants,
+  "ui-button": buttonUiColorVariants,
+  "theme-button": buttonThemeColorVariants,
+};

--- a/packages/kobber-components/src/button/Button.ts
+++ b/packages/kobber-components/src/button/Button.ts
@@ -20,7 +20,16 @@ export class Button extends KobberElementWithIcon implements ButtonProps {
   static styles: CSSResultGroup = [componentStyles, buttonStyles];
 
   @property()
-  variant: ButtonProps["variant"] = "brand-primary-main";
+  type: ButtonProps["type"] = "button";
+
+  @property({ attribute: "color-theme" })
+  colorTheme: ButtonProps["colorTheme"] = "brand";
+
+  @property({ attribute: "color-level" })
+  colorLevel: ButtonProps["colorLevel"] = "primary";
+
+  @property({ attribute: "color-variant" })
+  colorVariant: ButtonProps["colorVariant"] = "main";
 
   @property({ type: Boolean })
   iconFirst = false;
@@ -67,7 +76,6 @@ export class Button extends KobberElementWithIcon implements ButtonProps {
       <${tag}
         class=${[
           ...buttonClassNames({
-            variant: this.variant,
             hasIcon: this._hasIcon,
             iconOnly: this._iconOnly,
             iconFirst: this.iconFirst,
@@ -77,6 +85,10 @@ export class Button extends KobberElementWithIcon implements ButtonProps {
           }),
           this.className,
         ].join(" ")}
+        data-button-type="${this.type}"
+        data-color-theme="${this.colorTheme}"
+        data-color-level="${this.colorLevel}"
+        data-color-variant="${this.colorVariant}"
         ?disabled=${isLink ? undefined : this.disabled}
         href=${ifDefined(isLink && !this.disabled ? this.href : undefined)}
         target=${ifDefined(isLink ? this.target : undefined)}


### PR DESCRIPTION
The previous complex "variant" property is replaced with colorTheme, colorPriority and colorVariant.

This change entails some other enhancements:
- There is no more need to concat and split the variant string.
- New tokens are used, instead of guessing their transparency.
- Properties that are colors are given color property names, for readability. (Variant and level can mean a lot of things. Here they are colorVariant and colorLevel.)
- CSS selectors are changed from using loose class names, to data-attributes.