### PR TITLE
Add "use client" to icons react export

### DIFF
--- a/apps/docs/app/(web)/(routes)/_draftTools/DarkModeTrigger.tsx
+++ b/apps/docs/app/(web)/(routes)/_draftTools/DarkModeTrigger.tsx
@@ -1,5 +1,3 @@
-"use client"
-
 import { useState } from "react"
 import { KobberButton } from "@gyldendal/kobber-components/react"
 import { Moon, Sun } from "lucide-react"

--- a/apps/docs/app/(web)/(routes)/_draftTools/TokenMixer.tsx
+++ b/apps/docs/app/(web)/(routes)/_draftTools/TokenMixer.tsx
@@ -1,5 +1,3 @@
-"use client"
-
 import { useEffect, useState } from "react"
 import { KobberButton, KobberHeading } from "@gyldendal/kobber-components/react"
 import { Settings2Icon } from "lucide-react"

--- a/packages/kobber-icons/src/index.react.tsx
+++ b/packages/kobber-icons/src/index.react.tsx
@@ -1,3 +1,5 @@
+"use client"
+
 import { createComponent } from "@lit/react";
 import * as React from "react";
  

--- a/packages/kobber-icons/tsup-scripts/list-icons-and-components.ts
+++ b/packages/kobber-icons/tsup-scripts/list-icons-and-components.ts
@@ -25,7 +25,9 @@ export const listWebComponents = (symbols: NodeListOf<SVGSymbolElement>) => {
 };
 
 export const listReactComponents = (symbols: NodeListOf<SVGSymbolElement>) => {
-  const reactPreamble = `import { createComponent } from "@lit/react";
+  const reactPreamble = `"use client"
+
+import { createComponent } from "@lit/react";
 import * as React from "react";
 `;
 


### PR DESCRIPTION
Remove "use client" from docs, where now redundant.