### PR TITLE
Storybook render stories with lit html

### DIFF
--- a/apps/storybook-web-components/.storybook/preview.js
+++ b/apps/storybook-web-components/.storybook/preview.js
@@ -1,6 +1,7 @@
 import "@gyldendal/kobber-base/themes/default/tokens.css";
 import "@gyldendal/kobber-base/themes/dark/tokens.css";
 import theme from "./managerTheme";
+import { html } from "lit-html";
 
 const themes = [{ value: 'kobber-theme-default', title: 'Light' }, { value: 'kobber-theme-dark', title: 'Dark' } ];
 
@@ -19,6 +20,10 @@ const themes = [{ value: 'kobber-theme-default', title: 'Light' }, { value: 'kob
     },
     docs: {
       theme: theme,
+      source: {
+        language: "html",
+        excludeDecorators: true,
+      }
     },
   },
   // theme addon 👇
@@ -35,16 +40,20 @@ const themes = [{ value: 'kobber-theme-default', title: 'Light' }, { value: 'kob
       },
     },
   },
+  // replace when all stories use html`` in their render function
   decorators: [
-    (Story, context) => {
-      const story = Story();
-      // for supporting css variables
-      if (story instanceof HTMLElement) {
-        story.classList.add(context.globals.theme || themes[0].value);
-      }
-      return story;
-    },
+    (story, context) => html`<div class=${context.globals.theme}>${story()}</div>`,
   ],
+  // decorators: [
+  //   (Story, context) => {
+  //     const story = Story();
+  //     // for supporting css variables
+  //     if (story instanceof HTMLElement) {
+  //       story.classList.add(context.globals.theme || themes[0].value);
+  //     }
+  //     return story;
+  //   },
+  // ],
   //👇 Enables auto-generated documentation for all stories
   tags: ["autodocs"],
 };

--- a/apps/storybook-web-components/.storybook/preview.js
+++ b/apps/storybook-web-components/.storybook/preview.js
@@ -40,20 +40,9 @@ const themes = [{ value: 'kobber-theme-default', title: 'Light' }, { value: 'kob
       },
     },
   },
-  // replace when all stories use html`` in their render function
   decorators: [
     (story, context) => html`<div class=${context.globals.theme}>${story()}</div>`,
   ],
-  // decorators: [
-  //   (Story, context) => {
-  //     const story = Story();
-  //     // for supporting css variables
-  //     if (story instanceof HTMLElement) {
-  //       story.classList.add(context.globals.theme || themes[0].value);
-  //     }
-  //     return story;
-  //   },
-  // ],
   //👇 Enables auto-generated documentation for all stories
   tags: ["autodocs"],
 };

--- a/packages/kobber-components/src/accordion/Accordion.stories.ts
+++ b/packages/kobber-components/src/accordion/Accordion.stories.ts
@@ -1,11 +1,20 @@
 import type { Meta, StoryObj } from "@storybook/web-components-vite";
-import { accordionName } from "./Accordion.core";
+import { accordionName, type AccordionProps } from "./Accordion.core";
 import "../accordion/Accordion";
 import "../button/Button";
 import "../theme-context-provider/ThemeContext";
 import { init as initComponents } from "../base/init";
+import { html } from "lit";
 
 initComponents();
+
+interface Args extends AccordionProps {
+  title: string;
+  accordionCount: number;
+  itemText: string;
+  itemCount: number;
+  icon: "none" | "lock" | "label";
+}
 
 export default {
   title: "kobber.gyldendal.no/Accordion",
@@ -20,10 +29,6 @@ export default {
     itemText: {
       control: { type: "text" },
     },
-    itemElementType: {
-      options: ["none", "link", "button"],
-      control: { type: "select" },
-    },
     itemCount: {
       control: { type: "range", min: 0, max: 20 },
     },
@@ -33,63 +38,50 @@ export default {
     },
   },
   decorators: [
-    (Story, context) => `
-    <div style="height: 100vh;">
-      <kobber-theme-context theme-id=${context.globals.theme}>
-        ${Story()}
-      </kobber-theme-context>
+    (story, _) => html`
+    <div style="display: flex; flex-direction: column; align-items: center;">
+        ${story()}
     </div>`,
   ],
   parameters: {
-    layout: "centered",
+    layout: "padded",
   },
-} satisfies Meta;
+} satisfies Meta<Args>;
 
-export const Accordion: StoryObj = {
+export const Accordion: StoryObj<Args> = {
   args: {
     title: "Accordion",
     accordionCount: 2,
     itemText: "Item",
-    itemElementType: "link",
     itemCount: 3,
     icon: "none",
   },
-  render: args => [...Array(args.accordionCount).keys()].map((_, i) => getAccordion(args, i)).join(""),
+  render: args =>
+    html`${[...Array(args.accordionCount).keys()].map((_, i) => getAccordion(args, i))}`,
 };
 
 const getAccordion = (args: StoryObj["args"], i: number) =>
-  args &&
-  `
-    <kobber-accordion title="${args.title + " " + (i + 1)}">
-      <div style="display: flex; flex-direction: column;">
-        ${[...Array(args.itemCount).keys()].map(i => getSlot(args, i)).join("")}
-      </div>
+  args
+    ? html`
+    <kobber-accordion title="${`${args.title} ${i + 1}`}">
+      ${[...Array(args.itemCount).keys()].map(i => getSlot(args, i))}
     </kobber-accordion>
-`;
+`
+    : html``;
 
 const getSlot = (args: StoryObj["args"], i: number) => {
   if (!args) return "";
 
-  if (args.itemElementType === "link") {
-    return (
-      args &&
-      `<kobber-list-item><a href="#" style="text-decoration:none;color:#481125ff">${args.itemText} ${i + 1}</a>${getNamedSlot(args.icon)}</kobber-list-item>`
-    );
-  }
-
-  if (args.itemElementType === "button") {
-    return (
-      args &&
-      `<kobber-list-item><kobber-button>${args.itemText} ${i + 1}</kobber-button>${getNamedSlot(args.icon)}</kobber-list-item>`
-    );
-  }
-
-  return `<span style="display: flex; justify-content: space-evenly;">${args.itemText} ${i + 1} ${getNamedSlot(args.icon)}</span>`;
+  return html`
+      <kobber-list-item>
+        ${args.itemText} ${i + 1}${getIconSlot(args.icon)}
+      </kobber-list-item>
+      `;
 };
 
-const getNamedSlot = (icon: string) =>
+const getIconSlot = (icon: string) =>
   icon === "lock"
-    ? `<kobber-lock_locked slot="icon" />`
+    ? html` <kobber-lock_locked slot="icon" />`
     : icon === "label"
-      ? `<small slot="icon" style="color:red">kommer</small>`
+      ? html` <small slot="icon" style="color:red">kommer</small>`
       : "";

--- a/packages/kobber-components/src/aspect-ratio/AspectRatio.stories.ts
+++ b/packages/kobber-components/src/aspect-ratio/AspectRatio.stories.ts
@@ -1,9 +1,9 @@
+import * as tokens from "@gyldendal/kobber-base/themes/default/tokens.js";
 import type { Meta, StoryObj } from "@storybook/web-components-vite";
 import { html, unsafeCSS } from "lit";
-import * as tokens from "@gyldendal/kobber-base/themes/default/tokens.js";
-import { defaultAspectRatio } from "./AspectRatio";
-import { globalStyles } from "../story/globalStyles";
 import { init as initComponents } from "../base/init";
+import { obsoleteStyles } from "../story/obsoleteStyles";
+import { defaultAspectRatio } from "./AspectRatio";
 
 initComponents();
 
@@ -60,7 +60,7 @@ const render = (args: Args) => {
 export const AspectRatioStory: Story = {
   render,
   name: "AspectRatio",
-  decorators: [story => html`${globalStyles}${story()}`],
+  decorators: [story => html`${obsoleteStyles}${story()}`],
   parameters: { layout: "fullscreen" },
   args: { aspectRatio: defaultAspectRatio },
 };

--- a/packages/kobber-components/src/badge-icon/BadgeIcon.stories.ts
+++ b/packages/kobber-components/src/badge-icon/BadgeIcon.stories.ts
@@ -2,17 +2,17 @@ import type { Meta, StoryObj } from "@storybook/web-components-vite";
 import { html } from "lit";
 import "./BadgeIcon";
 import {
-  badgeIconName,
-  BadgeIconProps,
-  badgeIconSizes,
+  type BadgeIconProps,
   badgeIconColorThemes,
   badgeIconColorVariants,
+  badgeIconName,
+  badgeIconSizes,
 } from "./BadgeIcon.core";
 import "@gyldendal/kobber-icons/web-components";
 import "../theme-context-provider/ThemeContext";
-import { init as initComponents } from "../base/init";
 import { init as initIcons } from "@gyldendal/kobber-icons/init";
 import { ifDefined } from "lit/directives/if-defined.js";
+import { init as initComponents } from "../base/init";
 
 initComponents();
 initIcons();
@@ -21,12 +21,9 @@ interface Args extends BadgeIconProps {
   text?: string;
 }
 
-const meta: Meta = {
+const meta: Meta<Args> = {
   title: "Indicators/Badge Icon",
   component: badgeIconName,
-  decorators: [
-    (Story, context) => html`<kobber-theme-context theme-id=${context.globals.theme}>${Story()}</kobber-theme-context>`,
-  ],
   parameters: {
     layout: "centered",
   },
@@ -68,7 +65,7 @@ const renderBadgeIcon = (args: Args) => {
     color-theme="${ifDefined(colorTheme)}"
     color-variant="${ifDefined(colorVariant)}"
   >
-    <kobber-arrow_right slot="icon"></kobber-arrow_right>
+    <kobber-pin slot="icon"></kobber-pin>
     <span>${text}</span>
   </kobber-badge-icon>`;
 };

--- a/packages/kobber-components/src/badge-icon/BadgeIcon.stories.ts
+++ b/packages/kobber-components/src/badge-icon/BadgeIcon.stories.ts
@@ -11,7 +11,6 @@ import {
 import "@gyldendal/kobber-icons/web-components";
 import "../theme-context-provider/ThemeContext";
 import { init as initIcons } from "@gyldendal/kobber-icons/init";
-import { ifDefined } from "lit/directives/if-defined.js";
 import { init as initComponents } from "../base/init";
 
 initComponents();
@@ -61,9 +60,9 @@ const renderBadgeIcon = (args: Args) => {
   const { size, text, colorTheme, colorVariant } = args;
 
   return html` <kobber-badge-icon
-    size=${ifDefined(size)}
-    color-theme="${ifDefined(colorTheme)}"
-    color-variant="${ifDefined(colorVariant)}"
+    size=${size}
+    color-theme=${colorTheme}
+    color-variant=${colorVariant}
   >
     <kobber-pin slot="icon"></kobber-pin>
     <span>${text}</span>

--- a/packages/kobber-components/src/badge/Badge.stories.ts
+++ b/packages/kobber-components/src/badge/Badge.stories.ts
@@ -1,8 +1,15 @@
 import type { Meta, StoryObj } from "@storybook/web-components-vite";
 import { html } from "lit";
 import "./Badge";
-import { badgeName, BadgeProps, badgeSizes, badgeColorThemes, badgeColorVariants } from "./Badge.core";
+import {
+  type BadgeProps,
+  badgeColorThemes,
+  badgeColorVariants,
+  badgeName,
+  badgeSizes,
+} from "./Badge.core";
 import "../theme-context-provider/ThemeContext";
+import { ifDefined } from "lit/directives/if-defined.js";
 import { init as initComponents } from "../base/init";
 
 initComponents();
@@ -11,12 +18,9 @@ interface Args extends BadgeProps {
   text?: string;
 }
 
-const meta: Meta = {
+const meta: Meta<Args> = {
   title: "Indicators/Badge",
   component: badgeName,
-  decorators: [
-    (Story, context) => html`<kobber-theme-context theme-id=${context.globals.theme}>${Story()}</kobber-theme-context>`,
-  ],
   parameters: {
     layout: "centered",
   },
@@ -58,11 +62,11 @@ export const Badge: StoryObj<Args> = {
 const renderBadge = (args: Args) => {
   const { size, text, colorTheme, colorVariant, showStatusCircle } = args;
 
-  return html` <kobber-badge
+  return html`<kobber-badge
     size=${size}
     color-theme=${colorTheme}
     color-variant=${colorVariant}
-    ?show-status-circle=${showStatusCircle}
+    show-status-circle=${ifDefined(showStatusCircle ? "true" : undefined)}
   >
     ${text}
   </kobber-badge>`;

--- a/packages/kobber-components/src/badge/Badge.stories.ts
+++ b/packages/kobber-components/src/badge/Badge.stories.ts
@@ -9,7 +9,6 @@ import {
   badgeSizes,
 } from "./Badge.core";
 import "../theme-context-provider/ThemeContext";
-import { ifDefined } from "lit/directives/if-defined.js";
 import { init as initComponents } from "../base/init";
 
 initComponents();
@@ -66,7 +65,7 @@ const renderBadge = (args: Args) => {
     size=${size}
     color-theme=${colorTheme}
     color-variant=${colorVariant}
-    show-status-circle=${ifDefined(showStatusCircle ? "true" : undefined)}
+    ?show-status-circle=${showStatusCircle}
   >
     ${text}
   </kobber-badge>`;

--- a/packages/kobber-components/src/badge/Badge.ts
+++ b/packages/kobber-components/src/badge/Badge.ts
@@ -1,14 +1,10 @@
-import { property, state } from "lit/decorators.js";
-import { badgeClassNames, badgeName, BadgeProps } from "./Badge.core";
-import { CSSResultGroup, html, LitElement } from "lit";
-import componentStyles from "../base/styles/component.styles";
-import { badgeStyles } from "./Badge.styles";
-import { customElement } from "../base/utilities/customElementDecorator";
+import { type CSSResultGroup, html, LitElement } from "lit";
+import { property } from "lit/decorators.js";
 import { ifDefined } from "lit/directives/if-defined.js";
-
-/**
- * Kobber Badge web-component
- */
+import componentStyles from "../base/styles/component.styles";
+import { customElement } from "../base/utilities/customElementDecorator";
+import { type BadgeProps, badgeClassNames, badgeName } from "./Badge.core";
+import { badgeStyles } from "./Badge.styles";
 
 @customElement(badgeName)
 export class Badge extends LitElement implements BadgeProps {
@@ -26,12 +22,8 @@ export class Badge extends LitElement implements BadgeProps {
   @property({ type: Boolean, attribute: "show-status-circle" })
   showStatusCircle?: BadgeProps["showStatusCircle"];
 
-  connectedCallback() {
-    super.connectedCallback();
-  }
-
   render() {
-    return html` <div
+    return html`<div
       class="${[
         ...badgeClassNames({
           showStatusCircle: this.showStatusCircle,

--- a/packages/kobber-components/src/base/styles/focus.styles.ts
+++ b/packages/kobber-components/src/base/styles/focus.styles.ts
@@ -1,8 +1,8 @@
-import { css, unsafeCSS } from "lit";
 import { universal } from "@gyldendal/kobber-base/themes/tokens.css-variables.js";
+import { css, unsafeCSS } from "lit";
 
 export default css`
   outline: none;
-  box-shadow: 0 0 0 var(${unsafeCSS(universal.focus.border.width)}) var(${unsafeCSS(universal.focus.color)});
+  box-shadow: 0 0 0 var(${unsafeCSS(universal.focus.border.width)}) var(${unsafeCSS(universal.focus.border.color)});
   border-radius: var(${unsafeCSS(universal.focus.border.radius.xsmall)});
 `;

--- a/packages/kobber-components/src/button/Button.stories.ts
+++ b/packages/kobber-components/src/button/Button.stories.ts
@@ -147,7 +147,7 @@ export default meta;
 
 export const Button: StoryObj<Args> = {
   args: {
-    text: "Button text",
+    text: "Button <em>text</em>",
     colorTheme: allButtonColorThemes[0],
     colorLevel: allButtonColorLevels[0],
     colorVariant: allButtonColorVariants[0],
@@ -289,7 +289,7 @@ const renderButton = (args: Args) => {
   href=${link ? "#" : undefined}
   target=${link ? "_blank" : undefined}
 >
-  ${text ? text : ""}
+  ${text ? unsafeStatic(text) : ""}
   ${icon !== undefined && iconPosition !== "none" ? html`<${unsafeStatic(icon)} slot='icon' />` : ""}
 </kobber-button>
 `;

--- a/packages/kobber-components/src/button/Button.stories.ts
+++ b/packages/kobber-components/src/button/Button.stories.ts
@@ -20,7 +20,6 @@ import "@gyldendal/kobber-icons/web-components";
 import { component } from "@gyldendal/kobber-base/themes/tokens.css-variables.js";
 import { iconsList } from "@gyldendal/kobber-icons/symbols/kobber-icons-lists.ts";
 import type { IconType } from "@gyldendal/kobber-icons/symbols/kobber-icons-types.ts";
-import { ifDefined } from "lit/directives/if-defined.js";
 import { html, unsafeStatic } from "lit/static-html.js";
 import { isValidPropCombination } from "../base/internal/buttonUtils";
 
@@ -284,11 +283,11 @@ const renderButton = (args: Args) => {
   color-variant="${colorVariant}" 
   type="${type ? type : "button"}"
   aria-label="#"
-  disabled="${ifDefined(state === "disabled" ? true : undefined)}" 
-  icon-first=${ifDefined(iconPosition === "left" ? true : undefined)}
-  full-width=${ifDefined(fullWidth ? true : undefined)}
-  href=${ifDefined(link ? "#" : undefined)}
-  target=${ifDefined(link ? "_blank" : undefined)}
+  ?disabled=${state === "disabled"}
+  ?icon-first=${iconPosition === "left"}
+  ?full-width=${fullWidth}
+  href=${link ? "#" : undefined}
+  target=${link ? "_blank" : undefined}
 >
   ${text ? text : ""}
   ${icon !== undefined && iconPosition !== "none" ? html`<${unsafeStatic(icon)} slot='icon' />` : ""}

--- a/packages/kobber-components/src/button/Button.stories.ts
+++ b/packages/kobber-components/src/button/Button.stories.ts
@@ -245,13 +245,13 @@ const renderThemeAndVariantColors = (args: Args) => {
           return html`<span class="group-title" style="grid-area: variant-${index};">color-variant: ${colorVariant}</span>
             <div class="wrapper-buttons" style="grid-area: button-group-${index};">
               <div style="grid-area: buttons-iconRight-${index};">
-                ${states.map(state => renderButton({ ...args, state, text: state })).join("")}
+                ${states.map(state => renderButton({ ...args, state, text: state }))}
               </div>
               <div style="grid-area: buttons-${index};">
-                ${states.map(state => renderButton({ ...args, state, text: state, iconPosition: "none" })).join("")}
+                ${states.map(state => renderButton({ ...args, state, text: state, iconPosition: "none" }))}
               </div>
               <div style="grid-area: buttons-iconOnly-${index};">
-                ${states.map(state => renderButton({ ...args, state })).join("")}
+                ${states.map(state => renderButton({ ...args, state }))}
               </div>
             </div>`;
         } else {

--- a/packages/kobber-components/src/button/Button.stories.ts
+++ b/packages/kobber-components/src/button/Button.stories.ts
@@ -1,25 +1,27 @@
 import type { Meta, StoryObj } from "@storybook/web-components-vite";
 import {
-  ButtonColorLevel,
-  ButtonProps,
-  ButtonColorTheme,
-  ButtonColorVariant,
-  buttonName,
-  ButtonType,
-  buttonColorVariants,
+  type ButtonColorLevel,
+  type ButtonColorTheme,
+  type ButtonColorVariant,
+  type ButtonProps,
+  type ButtonType,
   buttonColorLevels,
   buttonColorThemes,
+  buttonColorVariants,
+  buttonName,
   buttonTypes,
 } from "./Button.core";
 import "./Button";
 import "../text/heading/Heading";
 import "../theme-context-provider/ThemeContext";
-import { init as initComponents } from "../base/init";
 import { init as initIcons } from "@gyldendal/kobber-icons/init";
+import { init as initComponents } from "../base/init";
 import "@gyldendal/kobber-icons/web-components";
-import { IconType } from "@gyldendal/kobber-icons/symbols/kobber-icons-types.ts";
-import { iconsList } from "@gyldendal/kobber-icons/symbols/kobber-icons-lists.ts";
 import { component } from "@gyldendal/kobber-base/themes/tokens.css-variables.js";
+import { iconsList } from "@gyldendal/kobber-icons/symbols/kobber-icons-lists.ts";
+import type { IconType } from "@gyldendal/kobber-icons/symbols/kobber-icons-types.ts";
+import { ifDefined } from "lit/directives/if-defined.js";
+import { html, unsafeStatic } from "lit/static-html.js";
 import { isValidPropCombination } from "../base/internal/buttonUtils";
 
 initComponents();
@@ -101,7 +103,7 @@ const meta: Meta<Args> = {
     icon: "kobber-arrow_right",
   },
   decorators: [
-    (Story, context) => `
+    (story, _) => html`
       <style>
       .level-group {
         display: flex;
@@ -137,9 +139,7 @@ const meta: Meta<Args> = {
         }
       }
     </style>
-    <kobber-theme-context theme-id=${context.globals.theme}>
-      ${Story()}
-    </kobber-theme-context>
+    ${story()}
     `,
   ],
 };
@@ -148,7 +148,7 @@ export default meta;
 
 export const Button: StoryObj<Args> = {
   args: {
-    text: "Button <em>text</em>",
+    text: "Button text",
     colorTheme: allButtonColorThemes[0],
     colorLevel: allButtonColorLevels[0],
     colorVariant: allButtonColorVariants[0],
@@ -158,7 +158,7 @@ export const Button: StoryObj<Args> = {
   },
   render: args => renderButton(args),
   decorators: [
-    Story => `
+    story => html`
     <style>
       .narrow-cointainer {
         display: flex;
@@ -168,7 +168,7 @@ export const Button: StoryObj<Args> = {
       }
     </style>
     <div class="narrow-cointainer">
-      ${Story()}
+      ${story()}
       <div class="wide-sibling"></div>
     </div>
     `,
@@ -215,14 +215,12 @@ const renderAllColors = (args: Args) => {
   const colorLevels = buttonColorLevels[args.type];
 
   if (colorLevels.length > 0) {
-    return colorLevels
-      .flatMap(colorLevel => {
-        args = { ...args, colorLevel };
-        return `<div class="level-group">
+    return html`${colorLevels.flatMap(colorLevel => {
+      args = { ...args, colorLevel };
+      return html`<div class="level-group">
         <kobber-heading level="h1" size="medium">color-level: ${colorLevel}</kobber-heading>
       ${renderThemeAndVariantColors(args)}</div>`;
-      })
-      .join("");
+    })}`;
   }
   return renderThemeAndVariantColors(args);
 };
@@ -231,15 +229,21 @@ const renderThemeAndVariantColors = (args: Args) => {
   const colorThemes = buttonColorThemes[args.type];
   const colorVariants = buttonColorVariants[args.type];
 
-  return colorThemes
-    .flatMap(
-      colorTheme => `<div class="wrapper-variant">
+  return html`${colorThemes.flatMap(
+    colorTheme => html`<div class="wrapper-variant">
       <kobber-heading level="h2" size="medium" style="grid-area: theme;">color-theme: ${colorTheme}</kobber-heading>
-      ${colorVariants
-        .flatMap((colorVariant, index) => {
-          args = { ...args, colorTheme, colorVariant };
-          if (isValidPropCombination(args.type, component, args.colorTheme, args.colorVariant, args.colorLevel)) {
-            return `<span class="group-title" style="grid-area: variant-${index};">color-variant: ${colorVariant}</span>
+      ${colorVariants.flatMap((colorVariant, index) => {
+        args = { ...args, colorTheme, colorVariant };
+        if (
+          isValidPropCombination(
+            args.type,
+            component,
+            args.colorTheme,
+            args.colorVariant,
+            args.colorLevel,
+          )
+        ) {
+          return html`<span class="group-title" style="grid-area: variant-${index};">color-variant: ${colorVariant}</span>
             <div class="wrapper-buttons" style="grid-area: button-group-${index};">
               <div style="grid-area: buttons-iconRight-${index};">
                 ${states.map(state => renderButton({ ...args, state, text: state })).join("")}
@@ -251,31 +255,43 @@ const renderThemeAndVariantColors = (args: Args) => {
                 ${states.map(state => renderButton({ ...args, state })).join("")}
               </div>
             </div>`;
-          }
-          return;
-        })
-        .join("")}</div>`,
-    )
-    .join("");
+        } else {
+          return html``;
+        }
+      })}</div>`,
+  )}`;
 };
 
 const renderButton = (args: Args) => {
-  const { type, colorLevel, colorTheme, colorVariant, state, icon, iconPosition, text, link, fullWidth } = args;
+  const {
+    type,
+    colorLevel,
+    colorTheme,
+    colorVariant,
+    state,
+    icon,
+    iconPosition,
+    text,
+    link,
+    fullWidth,
+  } = args;
 
-  return `
+  return html`
 <kobber-button 
   class="${state}" 
-  color-theme="${String(colorTheme)}" 
-  color-level="${String(colorLevel)}" 
-  color-variant="${String(colorVariant)}" 
+  color-theme="${colorTheme}" 
+  color-level="${colorLevel}" 
+  color-variant="${colorVariant}" 
   type="${type ? type : "button"}"
   aria-label="#"
-  ${state === "disabled" ? "disabled" : ""} 
-  ${iconPosition === "left" ? "icon-first" : ""} 
-  ${fullWidth ? "full-width" : ""} 
-  ${link ? "href='#' target='_blank'" : ""}>
+  disabled="${ifDefined(state === "disabled" ? true : undefined)}" 
+  icon-first=${ifDefined(iconPosition === "left" ? true : undefined)}
+  full-width=${ifDefined(fullWidth ? true : undefined)}
+  href=${ifDefined(link ? "#" : undefined)}
+  target=${ifDefined(link ? "_blank" : undefined)}
+>
   ${text ? text : ""}
-  ${icon !== undefined && iconPosition !== "none" ? `<${icon} slot='icon' />` : ""}
+  ${icon !== undefined && iconPosition !== "none" ? html`<${unsafeStatic(icon)} slot='icon' />` : ""}
 </kobber-button>
 `;
 };

--- a/packages/kobber-components/src/carousel/Carousel.stories.ts
+++ b/packages/kobber-components/src/carousel/Carousel.stories.ts
@@ -22,10 +22,6 @@ const meta: Meta<Args> = {
   args: {
     hasManyItems: true,
   },
-  decorators: [
-    (story, storyContext) =>
-      html`<kobber-theme-context theme-id=${storyContext.globals.theme}>${story()}</kobber-theme-context>`,
-  ],
 };
 
 export default meta;

--- a/packages/kobber-components/src/carousel/Carousel.stories.ts
+++ b/packages/kobber-components/src/carousel/Carousel.stories.ts
@@ -5,7 +5,7 @@ import "./CarouselButton";
 import "../layouts/horizontal-layout/HorizontalLayout";
 import "../layouts/horizontal-layout/HorizontalLayoutColumn";
 import "../story/ExampleCard";
-import { globalStyles } from "../story/globalStyles";
+import { obsoleteStyles } from "../story/obsoleteStyles";
 import { exampleIrregular, exampleRegular, miniExample } from "./story/example";
 import "../theme-context-provider/ThemeContext";
 import { init as initComponents } from "../base/init";
@@ -55,7 +55,7 @@ export const CarouselStory: StoryObj<Args> = {
       </kobber-carousel>
     </div>
   `,
-  decorators: [story => html`${globalStyles}${story()}`],
+  decorators: [story => html`${obsoleteStyles}${story()}`],
   parameters: { layout: "fullscreen" },
 };
 
@@ -67,6 +67,6 @@ export const IrregularCarouselStory: StoryObj<Args> = {
       <kobber-carousel> ${args.hasManyItems ? exampleIrregular : miniExample} </kobber-carousel>
     </div>
   `,
-  decorators: [story => html`${globalStyles}${story()}`],
+  decorators: [story => html`${obsoleteStyles}${story()}`],
   parameters: { layout: "fullscreen" },
 };

--- a/packages/kobber-components/src/checkbox/Checkbox.stories.ts
+++ b/packages/kobber-components/src/checkbox/Checkbox.stories.ts
@@ -2,9 +2,9 @@ import type { Meta, StoryObj } from "@storybook/web-components-vite";
 import "./checkbox-input/CheckboxInput";
 import "./checkbox-group/CheckboxGroup";
 import "../theme-context-provider/ThemeContext";
-import { type InputProps, type CheckboxState, checkboxColorThemes } from "./Checkbox.core";
-import { init as initComponents } from "../base/init";
 import { html } from "lit";
+import { init as initComponents } from "../base/init";
+import { type CheckboxState, checkboxColorThemes, type InputProps } from "./Checkbox.core";
 
 initComponents();
 

--- a/packages/kobber-components/src/checkbox/Checkbox.stories.ts
+++ b/packages/kobber-components/src/checkbox/Checkbox.stories.ts
@@ -24,11 +24,6 @@ interface Args extends Omit<InputProps, "checked"> {
 const meta: Meta = {
   title: "Base/Inputs/Checkbox",
   component: "kobber-checkbox",
-  decorators: [
-    (Story, context) => html`
-      <kobber-theme-context theme-id=${context.globals.theme}> ${Story()} </kobber-theme-context>
-    `,
-  ],
 };
 
 export default meta;

--- a/packages/kobber-components/src/checkbox/Checkbox.stories.ts
+++ b/packages/kobber-components/src/checkbox/Checkbox.stories.ts
@@ -27,9 +27,8 @@ const meta: Meta = {
 };
 
 export default meta;
-type Story = StoryObj;
 
-export const Themes: Story = {
+export const Themes: StoryObj<Args> = {
   render: args => {
     return html`
       <style>
@@ -135,8 +134,9 @@ const renderButton = (
       style="${lastStyles}"
       class="${className}"
       color-theme="${colorTheme}"
-      ${checked ? (checked === "indeterminate" ? "indeterminate" : "checked") : ""}
-      ${state === "disabled" ? "disabled" : ""}
+      ?indeterminate=${checked === "indeterminate"}
+      ?checked=${checked === true}
+      ?disabled=${state === "disabled"}
     >
       ${text}
     </kobber-checkbox-input>
@@ -146,15 +146,16 @@ const renderButton = (
 /**
  * For some reason, page need to be reloaded for controls to come into effect.
  */
-export const Checkbox: Story = {
+export const Checkbox: StoryObj<Args & { showAlert: boolean }> = {
   render: args => {
     return html`
       <kobber-checkbox-input 
-        color-theme="success" 
-        ${args.disabled ? "disabled" : ""}
-        ${args.checked}
         name="studentoption"
         id-value="totalpoints"
+        color-theme="success" 
+        ?indeterminate=${args.checked === "indeterminate"}
+        ?checked=${args.checked === "checked"}
+        ?disabled=${args.disabled}
       >
         <span>Vis ukas totalpoeng</span>
         ${args.showHelpText ? html`<span slot="help-text" style="font-style: italic;color:gray;">Læreren din har skrudd ${args.disabled ? "av" : "på"} denne innstillingen.</span>` : ""}
@@ -176,7 +177,9 @@ export const Checkbox: Story = {
   },
 };
 
-export const GNOExample: Story = {
+export const GNOExample: StoryObj<
+  Args & { showGroupHelpText: boolean; orientation: string; type: string }
+> = {
   render: args => {
     return html`
       <style>

--- a/packages/kobber-components/src/checkbox/Checkbox.stories.ts
+++ b/packages/kobber-components/src/checkbox/Checkbox.stories.ts
@@ -2,8 +2,9 @@ import type { Meta, StoryObj } from "@storybook/web-components-vite";
 import "./checkbox-input/CheckboxInput";
 import "./checkbox-group/CheckboxGroup";
 import "../theme-context-provider/ThemeContext";
-import { InputProps, CheckboxState, checkboxColorThemes } from "./Checkbox.core";
+import { type InputProps, type CheckboxState, checkboxColorThemes } from "./Checkbox.core";
 import { init as initComponents } from "../base/init";
+import { html } from "lit";
 
 initComponents();
 
@@ -24,7 +25,7 @@ const meta: Meta = {
   title: "Base/Inputs/Checkbox",
   component: "kobber-checkbox",
   decorators: [
-    (Story, context) => `
+    (Story, context) => html`
       <kobber-theme-context theme-id=${context.globals.theme}> ${Story()} </kobber-theme-context>
     `,
   ],
@@ -35,7 +36,7 @@ type Story = StoryObj;
 
 export const Themes: Story = {
   render: args => {
-    return `
+    return html`
       <style>
         :root {
           padding: 0.5rem;
@@ -71,17 +72,15 @@ export const Themes: Story = {
       </style>
 
       <ol>
-        ${checkboxColorThemes
-          .map(colorTheme =>
-            renderColorTheme({
-              colorTheme,
-              state: "idle",
-              text: "idle",
-              showHelpText: args.showHelpText,
-              showLabel: args.showLabel,
-            }),
-          )
-          .join("")}
+        ${checkboxColorThemes.map(colorTheme =>
+          renderColorTheme({
+            colorTheme,
+            state: "idle",
+            text: "idle",
+            showHelpText: args.showHelpText,
+            showLabel: args.showLabel,
+          }),
+        )}
       </ol>
     `;
   },
@@ -96,38 +95,32 @@ const renderColorTheme = (args: Args) => {
     return;
   }
 
-  return `<li>
+  return html`<li>
     ${colorTheme}
     <ol class="focusedOrNot">
-      ${states
-        .map(focusState =>
-          Object.keys(focusState).map(key => {
-            let focus = "";
-            const focusedOrNot = key;
-            if (focusedOrNot === "focus") {
-              focus = "focus";
-            }
-            return `<li class="states">
-            <span class="focusedOrNot-title">${focusedOrNot}:</span> ${checkedOrNot
-              .map(checked => {
-                if (typeof focusState[focusedOrNot] === "undefined") return;
-                const length = focusState[focusedOrNot].length;
+      ${states.map(focusState =>
+        Object.keys(focusState).map(key => {
+          let focus = "";
+          const focusedOrNot = key;
+          if (focusedOrNot === "focus") {
+            focus = "focus";
+          }
+          return html`<li class="states">
+            <span class="focusedOrNot-title">${focusedOrNot}:</span> ${checkedOrNot.map(checked => {
+              if (typeof focusState[focusedOrNot] === "undefined") return undefined;
+              const length = focusState[focusedOrNot].length;
 
-                return focusState[focusedOrNot]
-                  .map((state, index) => {
-                    let last = false;
-                    if (index === length - 1) {
-                      last = true;
-                    }
-                    return renderButton({ ...args, focus, state, text: state, checked, last });
-                  })
-                  .join("");
-              })
-              .join("")}
+              return focusState[focusedOrNot].map((state, index) => {
+                let last = false;
+                if (index === length - 1) {
+                  last = true;
+                }
+                return renderButton({ ...args, focus, state, text: state, checked, last });
+              });
+            })}
           </li>`;
-          }),
-        )
-        .join("")}
+        }),
+      )}
     </ol>
   </li>`;
 };
@@ -142,7 +135,7 @@ const renderButton = (
   const { colorTheme, focus, state, text, checked, last } = args;
   const className = `${focus} ${state}`;
   const lastStyles = last ? `grid-column: -1` : "";
-  return `
+  return html`
     <kobber-checkbox-input
       style="${lastStyles}"
       class="${className}"
@@ -160,7 +153,7 @@ const renderButton = (
  */
 export const Checkbox: Story = {
   render: args => {
-    return `
+    return html`
       <kobber-checkbox-input 
         color-theme="success" 
         ${args.disabled ? "disabled" : ""}
@@ -169,8 +162,8 @@ export const Checkbox: Story = {
         id-value="totalpoints"
       >
         <span>Vis ukas totalpoeng</span>
-        ${args.showHelpText ? `<span slot="help-text" style="font-style: italic;color:gray;">Læreren din har skrudd ${args.disabled ? "av" : "på"} denne innstillingen.</span>` : ""}
-        ${args.showAlert ? `<div slot="alert" style="background-color:#CBFBDB;padding: 0.5em;border-radius:0.5em;"><p class="badge">TODO: Use badge component.</p></div>` : ""}
+        ${args.showHelpText ? html`<span slot="help-text" style="font-style: italic;color:gray;">Læreren din har skrudd ${args.disabled ? "av" : "på"} denne innstillingen.</span>` : ""}
+        ${args.showAlert ? html`<div slot="alert" style="background-color:#CBFBDB;padding: 0.5em;border-radius:0.5em;"><p class="badge">TODO: Use badge component.</p></div>` : ""}
       </kobber-checkbox-input>
     `;
   },
@@ -190,7 +183,7 @@ export const Checkbox: Story = {
 
 export const GNOExample: Story = {
   render: args => {
-    return `
+    return html`
       <style>
         :root {
           padding: 0.5rem;
@@ -221,7 +214,7 @@ export const GNOExample: Story = {
           <kobber-checkbox-input id-value="childrens-books">Barnebøker</kobber-checkbox-input>
           <kobber-checkbox-input id-value="syllabi">Pensumbøker</kobber-checkbox-input>
           <kobber-checkbox-input id-value="professional">Profesjonsbøker</kobber-checkbox-input>
-        ${args.showGroupHelpText ? `<span slot="help-text">Velg noe, da.</span>` : ""}
+        ${args.showGroupHelpText ? html`<span slot="help-text">Velg noe, da.</span>` : ""}
         </kobber-checkbox-group>
       </div>
     `;

--- a/packages/kobber-components/src/divider/Divider.stories.ts
+++ b/packages/kobber-components/src/divider/Divider.stories.ts
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/web-components-vite";
-import { DividerVariant as DividerColorVariant, dividerVariants } from "./Divider.core";
+import { type DividerVariant as DividerColorVariant, dividerVariants } from "./Divider.core";
 import "./Divider";
 import { html } from "lit";
 import "../theme-context-provider/ThemeContext";
@@ -21,11 +21,6 @@ const meta: Meta = {
   parameters: {
     layout: "centered",
   },
-  decorators: [
-    (Story, context) => html`
-      <kobber-theme-context theme-id=${context.globals.theme}> ${Story()} </kobber-theme-context>
-    `,
-  ],
 };
 
 export default meta;

--- a/packages/kobber-components/src/grid/Grid.stories.ts
+++ b/packages/kobber-components/src/grid/Grid.stories.ts
@@ -3,12 +3,12 @@ import { html } from "lit";
 import "./Grid";
 import "./GridColumn";
 import "./GridColumnAspectRatio";
+import type { GridConfigId } from "./config/types";
 import { gridConfigs } from "./Grid.config";
-import { GridConfigId } from "./config/types";
 import "./story/ExampleCard";
-import { renderIndicators } from "./story/renderIndicators";
-import { globalStyles } from "../story/globalStyles";
 import { init as initComponents } from "../base/init";
+import { obsoleteStyles } from "../story/obsoleteStyles";
+import { renderIndicators } from "./story/renderIndicators";
 
 initComponents();
 
@@ -103,7 +103,7 @@ const render = (args: Args) => {
 export const GridStory: Story = {
   render,
   name: "Grid",
-  decorators: [story => html`${globalStyles}${story()}`],
+  decorators: [story => html`${obsoleteStyles}${story()}`],
   parameters: { layout: "fullscreen" },
   args: { gridConfig: gridConfigIds[0] },
 };

--- a/packages/kobber-components/src/index.css
+++ b/packages/kobber-components/src/index.css
@@ -333,7 +333,7 @@
     --typography-font-weight: var(--kobber-universal-text-body-text-weight);
     --typography-line-height: var([object Object]);
   
-            --padding: var(--kobber-component-badge-icon-padding-block-medium);
+            --padding: var(--kobber-component-badge-icon-padding-block-medium) 0;
             --gap: var(--kobber-component-badge-icon-gap-medium);
           }
 &[data-size="small"] { 
@@ -343,7 +343,7 @@
     --typography-font-weight: var(--kobber-universal-text-body-text-weight);
     --typography-line-height: var([object Object]);
   
-            --padding: var(--kobber-component-badge-icon-padding-block-small);
+            --padding: var(--kobber-component-badge-icon-padding-block-small) 0;
             --gap: var(--kobber-component-badge-icon-gap-small);
           }
   
@@ -2571,7 +2571,7 @@ em,
       &.focus {
         
   outline: none;
-  box-shadow: 0 0 0 var(--kobber-universal-focus-border-width) var(undefined);
+  box-shadow: 0 0 0 var(--kobber-universal-focus-border-width) var(--kobber-universal-focus-border-color);
   border-radius: var(--kobber-universal-focus-border-radius-xsmall);
 ;
         padding: 0.5rem;

--- a/packages/kobber-components/src/layouts/card-layout/CardLayout.stories.ts
+++ b/packages/kobber-components/src/layouts/card-layout/CardLayout.stories.ts
@@ -1,14 +1,14 @@
 import type { Meta, StoryObj } from "@storybook/web-components-vite";
-import { TemplateResult, html } from "lit";
+import { html, type TemplateResult } from "lit";
 import "../box-layout/BoxLayout";
 import "../story/ExampleCard";
 import "./CardLayout";
 import "./CardLayoutColumnAspectRatio";
+import { init as initComponents } from "../../base/init";
+import { obsoleteStyles } from "../../story/obsoleteStyles";
 import { example } from "./story/example";
 import { example6columns } from "./story/example6columns";
 import { renderIndicators } from "./story/renderIndicators";
-import { globalStyles } from "../../story/globalStyles";
-import { init as initComponents } from "../../base/init";
 
 initComponents();
 
@@ -43,7 +43,7 @@ const meta: Meta<Args> = {
     overrideContainerWidth: false,
     containerWidth: 800,
   },
-  decorators: [story => html`${globalStyles}${story()}`],
+  decorators: [story => html`${obsoleteStyles}${story()}`],
 };
 
 export default meta;

--- a/packages/kobber-components/src/layouts/horizontal-layout/HorizontalLayout.stories.ts
+++ b/packages/kobber-components/src/layouts/horizontal-layout/HorizontalLayout.stories.ts
@@ -4,18 +4,17 @@ import "../box-layout/BoxLayout";
 import "../story/ExampleCard";
 import "./HorizontalLayout";
 import "./HorizontalLayoutColumn";
+import { init as initComponents } from "../../base/init";
 import { exampleIrregular } from "../../carousel/story/example";
-import { renderIndicators } from "./story/renderIndicators";
 import { globalStyles } from "../../story/globalStyles";
 import { maxColumns } from "./HorizontalLayout.config";
-import { init as initComponents } from "../../base/init";
+import { renderIndicators } from "./story/renderIndicators";
 
 initComponents();
 
 const meta: Meta = {
   title: "In development 🔵/Layouts/HorizontalLayout (Carousel)",
   component: "HorizontalLayout",
-  decorators: [(story, storyContext) => html`<div class="${storyContext.globals.theme}">${story()}</div>`],
 };
 
 export default meta;

--- a/packages/kobber-components/src/layouts/horizontal-layout/HorizontalLayout.stories.ts
+++ b/packages/kobber-components/src/layouts/horizontal-layout/HorizontalLayout.stories.ts
@@ -6,7 +6,7 @@ import "./HorizontalLayout";
 import "./HorizontalLayoutColumn";
 import { init as initComponents } from "../../base/init";
 import { exampleIrregular } from "../../carousel/story/example";
-import { globalStyles } from "../../story/globalStyles";
+import { obsoleteStyles } from "../../story/obsoleteStyles";
 import { maxColumns } from "./HorizontalLayout.config";
 import { renderIndicators } from "./story/renderIndicators";
 
@@ -50,6 +50,6 @@ export const HorizontalLayoutStory: StoryObj = {
   name: "HorizontalLayout",
   render,
   play: ({ canvasElement }) => initIndicators(canvasElement),
-  decorators: [story => html`${globalStyles}${story()}`],
+  decorators: [story => html`${obsoleteStyles}${story()}`],
   parameters: { layout: "fullscreen" },
 };

--- a/packages/kobber-components/src/layouts/patterns/Patterns.stories.ts
+++ b/packages/kobber-components/src/layouts/patterns/Patterns.stories.ts
@@ -7,7 +7,7 @@ import {
 } from "../../carousel/story/example";
 import { example as cardLayoutExample } from "../card-layout/story/example";
 import "../story/ExampleSurface";
-import { globalStyles } from "../../story/globalStyles";
+import { obsoleteStyles } from "../../story/obsoleteStyles";
 import "../../theme-context-provider/ThemeContext";
 import { init as initComponents } from "../../base/init";
 
@@ -56,6 +56,6 @@ const render = (args: Args) => {
 export const GridStory: StoryObj<Args> = {
   render,
   name: "Page",
-  decorators: [story => html`${globalStyles}${story()}`],
+  decorators: [story => html`${obsoleteStyles}${story()}`],
   parameters: { layout: "fullscreen" },
 };

--- a/packages/kobber-components/src/layouts/patterns/Patterns.stories.ts
+++ b/packages/kobber-components/src/layouts/patterns/Patterns.stories.ts
@@ -1,11 +1,11 @@
 import type { Meta, StoryObj } from "@storybook/web-components-vite";
 import { html } from "lit";
 import "../box-layout/BoxLayout";
-import { example as cardLayoutExample } from "../card-layout/story/example";
 import {
-  exampleRegular as carouselExampleRegular,
   miniExample as carouselExampleMini,
+  exampleRegular as carouselExampleRegular,
 } from "../../carousel/story/example";
+import { example as cardLayoutExample } from "../card-layout/story/example";
 import "../story/ExampleSurface";
 import { globalStyles } from "../../story/globalStyles";
 import "../../theme-context-provider/ThemeContext";
@@ -23,10 +23,6 @@ const meta: Meta<Args> = {
   args: {
     carouselHasManyItems: true,
   },
-  decorators: [
-    (Story, storyContext) =>
-      html`<kobber-theme-context theme-id=${storyContext.globals.theme}>${Story()}</kobber-theme-context>`,
-  ],
 };
 
 export default meta;

--- a/packages/kobber-components/src/link/Link.mdx
+++ b/packages/kobber-components/src/link/Link.mdx
@@ -5,7 +5,9 @@ import * as LinkStories from "./Link.stories";
 
 # Nav Link
 
-To see Text Link, see Button stories and toggle the "Link" control.
+Links meant for menus and lists, not inline text. 
+
+Text Link has its own story.
 
 <Canvas of={LinkStories.Link} />
 

--- a/packages/kobber-components/src/link/Link.stories.ts
+++ b/packages/kobber-components/src/link/Link.stories.ts
@@ -1,10 +1,12 @@
 import type { Meta, StoryObj } from "@storybook/web-components-vite";
 import "./Link";
 import "@gyldendal/kobber-icons/web-components";
-import { LinkProps, linkTypes } from "./Link.core";
-import { init as initComponents } from "../base/init";
 import { init as initIcons } from "@gyldendal/kobber-icons/init";
+import { html } from "lit";
+import { ifDefined } from "lit/directives/if-defined.js";
+import { init as initComponents } from "../base/init";
 import { getPrintedState, linkStates } from "../story/linkStates";
+import { type LinkProps, linkTypes } from "./Link.core";
 
 initComponents();
 initIcons();
@@ -28,7 +30,6 @@ const meta: Meta<Args> = {
       control: { type: "radio" },
     },
   },
-  decorators: [(Story, context) => `<div class="${context.globals.theme}">${Story()}</div>`],
   parameters: {
     layout: "centered",
   },
@@ -46,43 +47,31 @@ export const Link: StoryObj<Args> = {
     icon: iconSettings[0],
   },
   render: args => {
-    return `<div style="max-width: 600px;">
-      <kobber-text-wrapper style="display: grid; gap: 1em;">
-        ${linkStates
-          .map(state => {
-            return `<p>
+    return html`
+      <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 1rem;">
+        ${linkStates.map(state => {
+          return html`
             <kobber-link
               class="${state}"
               href=${state !== "disabled" ? "https://github.com/GyldendalDigital/kobber" : undefined}
               type="${args.type}"
-              ${args.icon === "left" ? "icon-first" : ""}
+              icon-first="${ifDefined(args.icon === "left" ? true : undefined)}"
             >
-              ${args.text || `Lenke med tilstand ${getPrintedState(state)}`}
-              ${args.icon !== "none" ? `<kobber-arrow_right slot="icon" />` : ""}
+              ${args.text || html`link ${getPrintedState(state)}`}
+              ${args.icon !== "none" ? html`<kobber-arrow_right slot="icon" />` : ""}
             </kobber-link>
-          </p>`;
-          })
-          .join("")}
-      </kobber-text-wrapper>
-      <br />
-      <br />
-      <kobber-text-wrapper style="display: grid; gap: 1em;">
-        ${linkStates
-          .map(state => {
-            return `<p>
+
             <kobber-link
               class="${state}"
               onClick="alert('Hello world!')"
               type="${args.type}"
-              ${args.icon === "left" ? "icon-first" : ""}
+              icon-first="${ifDefined(args.icon === "left" ? true : undefined)}"
             >
-              ${args.text || `Knapp med tilstand ${getPrintedState(state)}`}
-              ${args.icon !== "none" ? `<kobber-arrow_right slot="icon" />` : ""}
+              ${args.text || html`button ${getPrintedState(state)}`}
+              ${args.icon !== "none" ? html`<kobber-arrow_right slot="icon" />` : ""}
             </kobber-link>
-          </p>`;
-          })
-          .join("")}
-      </kobber-text-wrapper>
+          `;
+        })}
     </div>`;
   },
 };

--- a/packages/kobber-components/src/link/Link.stories.ts
+++ b/packages/kobber-components/src/link/Link.stories.ts
@@ -3,7 +3,6 @@ import "./Link";
 import "@gyldendal/kobber-icons/web-components";
 import { init as initIcons } from "@gyldendal/kobber-icons/init";
 import { html } from "lit";
-import { ifDefined } from "lit/directives/if-defined.js";
 import { init as initComponents } from "../base/init";
 import { getPrintedState, linkStates } from "../story/linkStates";
 import { type LinkProps, linkTypes } from "./Link.core";
@@ -55,7 +54,7 @@ export const Link: StoryObj<Args> = {
               class="${state}"
               href=${state !== "disabled" ? "https://github.com/GyldendalDigital/kobber" : undefined}
               type="${args.type}"
-              icon-first="${ifDefined(args.icon === "left" ? true : undefined)}"
+              ?icon-first=${args.icon === "left"}
             >
               ${args.text || html`link ${getPrintedState(state)}`}
               ${args.icon !== "none" ? html`<kobber-arrow_right slot="icon" />` : ""}
@@ -65,7 +64,7 @@ export const Link: StoryObj<Args> = {
               class="${state}"
               onClick="alert('Hello world!')"
               type="${args.type}"
-              icon-first="${ifDefined(args.icon === "left" ? true : undefined)}"
+              ?icon-first=${args.icon === "left"}
             >
               ${args.text || html`button ${getPrintedState(state)}`}
               ${args.icon !== "none" ? html`<kobber-arrow_right slot="icon" />` : ""}

--- a/packages/kobber-components/src/list/List.core.ts
+++ b/packages/kobber-components/src/list/List.core.ts
@@ -4,8 +4,6 @@ export type ListProps = {
   orientation?: ListOrientation;
 };
 
-type ListOrientation = "vertical" | "horizontal";
+type ListOrientation = (typeof ListOrientations)[number];
 
-type ListClassNames = typeof listName | ListOrientation;
-
-export const listClassNames = (...classNames: ListClassNames[]) => classNames?.join(" ");
+export const ListOrientations = ["vertical", "horizontal"] as const;

--- a/packages/kobber-components/src/list/List.stories.ts
+++ b/packages/kobber-components/src/list/List.stories.ts
@@ -1,8 +1,9 @@
 import type { Meta, StoryObj } from "@storybook/web-components-vite";
-import { listName, ListProps } from "./List.core";
+import { listName, ListOrientations, type ListProps } from "./List.core";
 import "./List";
 import "../theme-context-provider/ThemeContext";
 import { init as initComponents } from "../base/init";
+import { html } from "lit";
 
 initComponents();
 
@@ -11,7 +12,8 @@ const states = ["idle", "hover", "active", "focus", "disabled"] as const;
 const buttonIconSettings = ["none", "lock", "label"] as const;
 
 interface Args extends ListProps {
-  text?: string;
+  itemText?: string;
+  itemCount: number;
   icon: (typeof buttonIconSettings)[number];
 }
 
@@ -20,20 +22,17 @@ export default {
   component: listName,
   argTypes: {
     orientation: {
-      options: ["vertical", "horizontal"],
+      options: ListOrientations,
       control: { type: "select" },
+    },
+    itemCount: {
+      control: { type: "range", min: 0, max: 20 },
     },
     icon: {
       options: buttonIconSettings,
       control: { type: "select" },
     },
   },
-  decorators: [
-    (Story, context) => `
-    <kobber-theme-context theme-id=${context.globals.theme}>
-      ${Story()}
-    </kobber-theme-context>`,
-  ],
   parameters: {
     layout: "centered",
   },
@@ -41,21 +40,42 @@ export default {
 
 export const List: StoryObj<Args> = {
   args: {
-    text: "",
+    itemText: "List item",
+    itemCount: 3,
     orientation: "vertical",
     icon: "none",
   },
-  render: args => `
-    <div style="width: 200px">
+  render: args =>
+    html`
       <kobber-list orientation=${args.orientation}>
-        ${states
-          .map(
-            state =>
-              `<kobber-list-item ${state} class="${state}">${args.text || state} ${getNamedSlot(args.icon)}</kobber-list-item>`,
-          )
-          .join("")}
+        ${[...Array(args.itemCount).keys()].map(
+          i =>
+            html`
+            <kobber-list-item>
+              ${args.itemText} ${i + 1} ${getNamedSlot(args.icon)}
+            </kobber-list-item>
+            `,
+        )}
       </kobber-list>
-    </div>
+      `,
+};
+
+export const Lists: StoryObj<Args> = {
+  args: {
+    itemText: "",
+    orientation: "vertical",
+    icon: "none",
+  },
+  render: args => html`
+      <kobber-list orientation=${args.orientation}>
+        ${states.map(
+          state => html`
+          <kobber-list-item ${state} class="${state}">
+            ${args.itemText || state} ${getNamedSlot(args.icon)}
+          </kobber-list-item>
+          `,
+        )}
+      </kobber-list>
   `,
 };
 

--- a/packages/kobber-components/src/list/List.stories.ts
+++ b/packages/kobber-components/src/list/List.stories.ts
@@ -1,9 +1,9 @@
 import type { Meta, StoryObj } from "@storybook/web-components-vite";
-import { listName, ListOrientations, type ListProps } from "./List.core";
+import { ListOrientations, type ListProps, listName } from "./List.core";
 import "./List";
 import "../theme-context-provider/ThemeContext";
-import { init as initComponents } from "../base/init";
 import { html } from "lit";
+import { init as initComponents } from "../base/init";
 
 initComponents();
 
@@ -81,7 +81,7 @@ export const Lists: StoryObj<Args> = {
 
 const getNamedSlot = (icon: string) =>
   icon === "lock"
-    ? `<kobber-lock_locked slot="icon" />`
+    ? html`<kobber-lock_locked slot="icon" />`
     : icon === "label"
-      ? `<small slot="icon" style="color:red;font-size:10px">kommer</small>`
+      ? html`<small slot="icon" style="color:red;font-size:10px">kommer</small>`
       : "";

--- a/packages/kobber-components/src/list/List.styles.ts
+++ b/packages/kobber-components/src/list/List.styles.ts
@@ -1,10 +1,10 @@
 import { component } from "@gyldendal/kobber-base/themes/tokens.css-variables.js";
 import { css, unsafeCSS } from "lit";
-import { listClassNames } from "./List.core";
+import { listName } from "./List.core";
 
 const createListStyles = () => {
   return css`
-    .${unsafeCSS(listClassNames("kobber-list"))} {
+    .${unsafeCSS(listName)} {
       display: flex;
       flex-direction: column;
       align-items: stretch;

--- a/packages/kobber-components/src/list/List.ts
+++ b/packages/kobber-components/src/list/List.ts
@@ -1,8 +1,8 @@
-import { CSSResultGroup, html } from "lit";
+import { type CSSResultGroup, html } from "lit";
 import { property } from "lit/decorators.js";
 import "./ListItem";
 import KobberElement from "../base/kobber-element";
-import { listClassNames, listName, ListProps } from "./List.core";
+import { listName, type ListProps } from "./List.core";
 import componentStyles from "../base/styles/component.styles";
 import { listStyles } from "./List.styles";
 import { ifDefined } from "lit/directives/if-defined.js";
@@ -35,7 +35,7 @@ export class List extends KobberElement implements ListProps {
   override render() {
     return html`
       <div
-        class="${listClassNames(listName)}"
+        class="${listName}"
         role="${this.role ?? "menubar"}"
         aria-orientation="${ifDefined(this.orientation)}"
         tabindex="-1"

--- a/packages/kobber-components/src/radio/Radio.core.ts
+++ b/packages/kobber-components/src/radio/Radio.core.ts
@@ -12,7 +12,9 @@ export const radioInputLabelClassName = "label";
 
 const radioTokens = component._radiobutton;
 
-export const inputClassNames = ({ isLink = false }: InputProps & InputComputedProps): InputClassNames[] => {
+export const inputClassNames = ({
+  isLink = false,
+}: InputProps & InputComputedProps): InputClassNames[] => {
   const conditionalClassNames: InputClassNames[] = [];
 
   if (isLink) {
@@ -24,7 +26,7 @@ export const inputClassNames = ({ isLink = false }: InputProps & InputComputedPr
 
 export type GroupProps = {
   currentValue?: string;
-  direction?: "vertical" | "horizontal";
+  direction?: (typeof directions)[number];
   form?: string;
   label?: string;
   name?: string;
@@ -51,9 +53,12 @@ export type ControlProps = {
 export type GroupClassNames = typeof radioGroupName;
 export type InputLabelClassNames = typeof radioInputLabelClassName;
 export type InputControlClassNames = typeof radioInputControlName;
-export type InputControlPartNames = typeof radioInputControlPartName | typeof radioInputControlPartNameChecked;
+export type InputControlPartNames =
+  | typeof radioInputControlPartName
+  | typeof radioInputControlPartNameChecked;
 export type InputClassNames = typeof radioInputName | typeof radioInputAsLinkClassName;
 
 export type InputColorTheme = (typeof inputColorThemes)[number];
 
 export const inputColorThemes = objectKeys(radioTokens.indicator.border.color);
+export const directions = ["vertical", "horizontal"] as const;

--- a/packages/kobber-components/src/radio/Radio.stories.ts
+++ b/packages/kobber-components/src/radio/Radio.stories.ts
@@ -2,9 +2,10 @@ import type { Meta, StoryObj } from "@storybook/web-components-vite";
 import "./radio-input/RadioInput";
 import "./radio-group/RadioGroup";
 import { primitives } from "@gyldendal/kobber-base/themes/default/tokens.js";
-import { inputColorThemes, InputProps, radioInputName } from "./Radio.core";
+import { type GroupProps, type InputProps, inputColorThemes, radioInputName } from "./Radio.core";
 import "../text/heading/Heading";
 import "../theme-context-provider/ThemeContext";
+import { html } from "lit";
 import { init as initComponents } from "../base/init";
 
 initComponents();
@@ -14,12 +15,8 @@ const states: { [key: string]: string[] }[] = [
   { "not focus": ["idle", "hover", "active", "disabled"] },
   { focus: ["idle", "hover", "active"] },
 ] as const;
-enum Direction {
-  horizontal = "horizontal",
-  vertical = "vertical",
-}
 
-const helpTextElement = `<p slot="help-text">
+const helpTextElement = html`<p slot="help-text">
   Vi anbefaler <em>lydbok</em> (ref <a href="https://vg.no">VG</a>).
 </p>`;
 
@@ -28,7 +25,7 @@ interface Args extends InputProps {
   state: string;
   link: boolean;
   currentValue: (typeof formats)[number];
-  direction: Direction;
+  direction: GroupProps["direction"];
   showHelpText: boolean;
   showLabel: boolean;
 }
@@ -36,20 +33,12 @@ interface Args extends InputProps {
 const meta: Meta<Args> = {
   title: "Base/Inputs/Radio",
   component: radioInputName,
-  decorators: [
-    (Story, context) => `
-      <kobber-theme-context theme-id=${context.globals.theme}>
-        ${Story()}
-      </kobber-theme-context>
-      `,
-  ],
 };
 export default meta;
-type Story = StoryObj;
 
-export const Themes: Story = {
+export const Themes: StoryObj<Args> = {
   render: args => {
-    return `
+    return html`
       <style>
         :root {
           padding: 0.5rem;
@@ -85,20 +74,18 @@ export const Themes: Story = {
       </style>
 
       <ol>
-        ${inputColorThemes
-          .map(colorTheme =>
-            renderColorTheme({
-              colorTheme,
-              state: "idle",
-              text: "idle",
-              link: false,
-              currentValue: args.currentValue,
-              direction: args.direction,
-              showHelpText: args.showHelpText,
-              showLabel: args.showLabel,
-            }),
-          )
-          .join("")}
+        ${inputColorThemes.map(colorTheme =>
+          renderColorTheme({
+            colorTheme,
+            state: "idle",
+            text: "idle",
+            link: false,
+            currentValue: args.currentValue,
+            direction: args.direction,
+            showHelpText: args.showHelpText,
+            showLabel: args.showLabel,
+          }),
+        )}
         </ol>
     `;
   },
@@ -113,35 +100,31 @@ const renderColorTheme = (args: Args) => {
     return;
   }
 
-  return `<li>${colorTheme}
-  <ol class="focusedOrNot">${states
-    .map(focusState =>
-      Object.keys(focusState).map(key => {
-        let focus = "";
-        const focusedOrNot = key;
-        if (focusedOrNot === "focus") {
-          focus = "focus";
-        }
-        return `<li class="states"><span class="focusedOrNot-title">${focusedOrNot}:</span> ${checkedOrNot
-          .map(checked => {
-            if (typeof focusState[focusedOrNot] === "undefined") return;
-            const length = focusState[focusedOrNot].length;
+  return html`<li>${colorTheme}
+  <ol class="focusedOrNot">${states.map(focusState =>
+    Object.keys(focusState).map(key => {
+      let focus = "";
+      const focusedOrNot = key;
+      if (focusedOrNot === "focus") {
+        focus = "focus";
+      }
+      return html`<li class="states"><span class="focusedOrNot-title">${focusedOrNot}:</span> ${checkedOrNot.map(
+        checked => {
+          if (typeof focusState[focusedOrNot] === "undefined") return html``;
+          const length = focusState[focusedOrNot].length;
 
-            return `${focusState[focusedOrNot]
-              .map((state, index) => {
-                let last = false;
-                if (index === length - 1) {
-                  last = true;
-                }
-                return renderButton({ ...args, focus, state, text: state, checked, last });
-              })
-              .join("")}`;
-          })
-          .join("")}
+          return html`${focusState[focusedOrNot].map((state, index) => {
+            let last = false;
+            if (index === length - 1) {
+              last = true;
+            }
+            return renderButton({ ...args, focus, state, text: state, checked, last });
+          })}`;
+        },
+      )}
           </li>`;
-      }),
-    )
-    .join("")}
+    }),
+  )}
   </ol></li>`;
 };
 
@@ -155,7 +138,7 @@ const renderButton = (
   const { colorTheme, focus, state, text, link, checked, last } = args;
   const className = `${focus} ${state}`;
   const lastStyles = last ? `grid-column: -1` : "";
-  return `
+  return html`
 <kobber-radio-input 
   style="${lastStyles}"
   class="${className}" 
@@ -168,9 +151,9 @@ const renderButton = (
 `;
 };
 
-export const GNOExample: Story = {
+export const GNOExample: StoryObj<Args> = {
   render: args => {
-    return `
+    return html`
       <style>
         :root {
           padding: 0.5rem;
@@ -252,9 +235,9 @@ export const GNOExample: Story = {
   },
 };
 
-export const SkolestudioExamples: Story = {
+export const SkolestudioExamples: StoryObj<Args> = {
   render: args => {
-    return `
+    return html`
       <style>
         :root {
           padding: 0.5rem;

--- a/packages/kobber-components/src/radio/Radio.stories.ts
+++ b/packages/kobber-components/src/radio/Radio.stories.ts
@@ -142,10 +142,10 @@ const renderButton = (
 <kobber-radio-input 
   style="${lastStyles}"
   class="${className}" 
-  colorTheme="${String(colorTheme)}" 
-  ${checked ? "checked" : ""} 
-  ${state === "disabled" ? "disabled" : ""} 
-  ${link ? "href='#'" : ""}>
+  colorTheme="${colorTheme}" 
+  ?checked=${checked === true}
+  ?disabled=${state === "disabled"}
+  href="${link ? "#" : ""}">
   ${text}
 </kobber-radio-input>
 `;

--- a/packages/kobber-components/src/story/linkStates.ts
+++ b/packages/kobber-components/src/story/linkStates.ts
@@ -1,4 +1,6 @@
+import { html } from "lit";
+
 const notPseudoClassStates = ["idle"];
 export const linkStates = ["idle", "active", "hover", "focus", "disabled"];
 export const getPrintedState = (state: string) =>
-  notPseudoClassStates.indexOf(state) ? `<code>:${state}</code>` : state;
+  notPseudoClassStates.indexOf(state) ? html`<code>:${state}</code>` : "";

--- a/packages/kobber-components/src/story/obsoleteStyles.ts
+++ b/packages/kobber-components/src/story/obsoleteStyles.ts
@@ -1,6 +1,7 @@
 import { html } from "lit";
 
-export const globalStyles = html`
+/** @deprecated Styles used in deprecated components */
+export const obsoleteStyles = html`
   <style>
     html {
       box-sizing: border-box;

--- a/packages/kobber-components/src/text/Text.stories.ts
+++ b/packages/kobber-components/src/text/Text.stories.ts
@@ -39,7 +39,6 @@ initIcons();
 
 const meta: Meta = {
   title: "Styles and Foundation/Text",
-  decorators: [(Story, context) => html`<div class="${context.globals.theme}">${Story()}</div>`],
   parameters: {
     layout: "centered",
   },

--- a/packages/kobber-components/src/text/Text.stories.ts
+++ b/packages/kobber-components/src/text/Text.stories.ts
@@ -10,29 +10,29 @@ import "./lead/Lead";
 import "./text-link/TextLink";
 import {
   headingColors,
-  headingSizes,
   headingColorVariants,
   headingFonts,
+  headingSizes,
 } from "./heading/Heading.core";
 import "@gyldendal/kobber-icons/web-components";
-import { init as initComponents } from "../base/init";
 import { init as initIcons } from "@gyldendal/kobber-icons/init";
+import { init as initComponents } from "../base/init";
 import { getPrintedState, linkStates } from "../story/linkStates";
-import { leadColors, leadColorVariants } from "./lead/Lead.core";
 import { displayFonts, displaySizes } from "./display/Display.core";
-import { titleColors, titleColorVariants, titleFonts, titleSizes } from "./title/Title.core";
+import { leadColors, leadColorVariants } from "./lead/Lead.core";
 import {
   textBodyColors,
   textBodyColorVariants,
+  textBodyContexts,
   textBodyFonts,
   textBodySizes,
-  textBodyContexts,
 } from "./text-body/TextBody.core";
 import {
   textLabelColors,
   textLabelColorVariants,
   textLabelSizes,
 } from "./text-label/TextLabel.core";
+import { titleColors, titleColorVariants, titleFonts, titleSizes } from "./title/Title.core";
 
 initComponents();
 initIcons();
@@ -440,20 +440,17 @@ export const Link: Story = {
     icon: false,
   },
   render: args => {
-    return html`<div style="max-width: 600px;">
-      <kobber-text-wrapper>
+    return html`<div style="display: flex; flex-direction: column; gap: 1rem;">
         ${linkStates.map(state => {
-          return html`<p>
+          return html`
             <kobber-text-link
               class="${state}"
               href=${state !== "disabled" ? "https://github.com/GyldendalDigital/kobber" : ""}
             >
-              Lenke ${args.icon ? html`<kobber-external_link_arrow />` : null}
+              ${args.text || html`link ${args.icon ? html`<kobber-external_link_arrow />` : null} ${getPrintedState(state)}`}
             </kobber-text-link>
-            med tilstand ${getPrintedState(state)}
-          </p>`;
+          `;
         })}
-      </kobber-text-wrapper>
     </div>`;
   },
 };

--- a/packages/kobber-components/src/text/text-link/TextLink.styles.ts
+++ b/packages/kobber-components/src/text/text-link/TextLink.styles.ts
@@ -1,7 +1,7 @@
-import { css, unsafeCSS } from "lit";
 import { component, universal } from "@gyldendal/kobber-base/themes/tokens.css-variables.js";
-import { textLinkName } from "./TextLink.core";
+import { css, unsafeCSS } from "lit";
 import focusStyles from "../../base/styles/focus.styles";
+import { textLinkName } from "./TextLink.core";
 
 /**
  * TODO: svg from icon component

--- a/packages/kobber-icons/tsup-scripts/make-storybook-story.ts
+++ b/packages/kobber-icons/tsup-scripts/make-storybook-story.ts
@@ -6,6 +6,7 @@ export const makeStory = (symbol: SVGSymbolElement) => {
   return `import type { Args, Meta, StoryObj } from "@storybook/web-components";
 import { init as initIcons } from "@gyldendal/kobber-icons/init";
 import "@gyldendal/kobber-icons/web-components";
+import { html } from "lit";
 
 initIcons();
 
@@ -22,22 +23,13 @@ const meta: Meta = {
   argTypes: {
     size: { control: "inline-radio", options: ["small", "medium", "large"] },
   },
-  decorators: [
-    (story, storyContext) => \`
-      <div class="\${storyContext.globals.theme}">
-        \${story()}
-      </div>
-    \`,
-  ],
 };
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const ${iconNames.unprefixed}: Story = {
-  render: (args: Args) => \`
-    <${symbol.id} aria-label="\${args.ariaLabel}" size="\${args.size}" />
-  \`,
+  render: (args: Args) => html\`<${symbol.id} aria-label="\${args.ariaLabel}" size="\${args.size}" />\`,
 };
 `;
 };


### PR DESCRIPTION
- Added lit html syntax to all stories instead of simple template strings
- Added global decorator wich adds theme class
- Removed decorators from code snippets

Pros:
- Better syntax highlighting in IDE
- Storybook docs code snippets are encoded correctly

Code snippet before / after:
<img width="1094" height="1037" alt="image" src="https://github.com/user-attachments/assets/518e7296-daaf-489f-9c58-0dab8b2c3056" />
<img width="1136" height="258" alt="image" src="https://github.com/user-attachments/assets/accf6491-e53c-4d39-bdaf-326c3375c9d5" />

Cons:
- Lit html strips conditional attributes which means this story
```
<kobber-badge
    ${showStatusCircle ? "show-status-circle" : ""}
```
must be written like this:
```
<kobber-badge
    ?show-status-circle=${showStatusCircle}
```
