### PR TITLE
replace customElement decorator from lit with custom decorator

### DIFF
--- a/packages/kobber-components/src/checkbox/checkbox-group/CheckboxGroup.ts
+++ b/packages/kobber-components/src/checkbox/checkbox-group/CheckboxGroup.ts
@@ -1,6 +1,6 @@
 import { html, unsafeStatic } from "lit/static-html.js";
 import type { CSSResultGroup } from "lit";
-import { customElement, property, query, state } from "lit/decorators.js";
+import { property, query, state } from "lit/decorators.js";
 import ShoelaceElement from "../../base/internal/shoelace-element";
 import { HasSlotController } from "../../base/internal/slot";
 import type { ShoelaceFormControl } from "../../base/internal/shoelace-element";
@@ -12,8 +12,9 @@ import {
 } from "../../base/internal/form";
 import componentStyles from "../../base/styles/component.styles";
 import type { CheckboxInput } from "../checkbox-input/CheckboxInput";
-import { checkboxGroupName, checkboxInputName, GroupProps } from "../Checkbox.core";
+import { checkboxGroupName, checkboxInputName, type GroupProps } from "../Checkbox.core";
 import { checkboxGroupStyles } from "./CheckboxGroup.styles";
+import { customElement } from "../../base/utilities/customElementDecorator";
 
 /**
  * @summary Checkbox groups are used to group multiple [checkboxes](/components/checkbox).

--- a/packages/kobber-components/src/layouts/story/ExampleCard.ts
+++ b/packages/kobber-components/src/layouts/story/ExampleCard.ts
@@ -1,7 +1,8 @@
 import * as tokens from "@gyldendal/kobber-base/themes/default/tokens.js";
 import { ResizeController } from "@lit-labs/observers/resize-controller.js";
 import { LitElement, css, html, unsafeCSS } from "lit";
-import { customElement, property } from "lit/decorators.js";
+import { property } from "lit/decorators.js";
+import { customElement } from "../../base/utilities/customElementDecorator";
 
 const paddingBlock = "16px";
 

--- a/packages/kobber-components/src/radio/radio-group/RadioGroup.ts
+++ b/packages/kobber-components/src/radio/radio-group/RadioGroup.ts
@@ -13,9 +13,9 @@ import {
 } from "../../base/internal/form";
 import componentStyles from "../../base/styles/component.styles";
 import type { RadioInput } from "../radio-input/RadioInput";
-import { radioGroupName, radioInputName, GroupProps } from "../Radio.core";
+import { radioGroupName, radioInputName, type GroupProps } from "../Radio.core";
 import { radioGroupStyles } from "./RadioGroup.styles";
-import { customElement } from "../../base/utilities/customElementDecorator";
+import { customElement } from "lit/decorators.js";
 
 /**
  * @summary Radio groups are used to group multiple [radio inputs](/components/radio-input) so they function as a single form control.
@@ -111,7 +111,7 @@ export class RadioGroup extends ShoelaceElement implements Props {
     super.connectedCallback();
     this.value = this.currentValue;
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
+    // @ts-expect-error
     navigation.addEventListener("navigate", () => {
       // Experimental functionality, does not work in Firefox. Might change in the future.
       this.handleUrlChange();


### PR DESCRIPTION
Causing error when using Lit's customElement decorator, because it doesn't check for existing registrations

<img width="692" height="110" alt="image" src="https://github.com/user-attachments/assets/9b1986e7-713e-4814-b31f-638af54dab22" />
